### PR TITLE
Adding APER encoding in to skeletons like O-RAN

### DIFF
--- a/skeletons/BIT_STRING.c
+++ b/skeletons/BIT_STRING.c
@@ -35,9 +35,13 @@ asn_TYPE_operation_t asn_OP_BIT_STRING = {
 #ifdef	ASN_DISABLE_PER_SUPPORT
 	0,
 	0,
+	0,
+	0,
 #else
 	BIT_STRING_decode_uper,	/* Unaligned PER decoder */
 	BIT_STRING_encode_uper,	/* Unaligned PER encoder */
+	OCTET_STRING_decode_aper,	/* Aligned PER decoder */
+	OCTET_STRING_encode_aper,	/* Aligned PER encoder */
 #endif  /* ASN_DISABLE_PER_SUPPORT */
 	BIT_STRING_random_fill,
 	0	/* Use generic outmost tag fetcher */
@@ -92,7 +96,7 @@ asn_enc_rval_t
 BIT_STRING_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
                       int ilevel, enum xer_encoder_flags_e flags,
                       asn_app_consume_bytes_f *cb, void *app_key) {
-    asn_enc_rval_t er;
+	asn_enc_rval_t er = {0, 0, 0};
 	char scratch[128];
 	char *p = scratch;
 	char *scend = scratch + (sizeof(scratch) - 10);

--- a/skeletons/BIT_STRING.h
+++ b/skeletons/BIT_STRING.h
@@ -38,6 +38,8 @@ asn_random_fill_f  BIT_STRING_random_fill;
 #define BIT_STRING_decode_ber        OCTET_STRING_decode_ber
 #define BIT_STRING_encode_der        OCTET_STRING_encode_der
 #define BIT_STRING_decode_xer        OCTET_STRING_decode_xer_binary
+#define BIT_STRING_decode_aper       OCTET_STRING_decode_aper
+#define BIT_STRING_encode_aper       OCTET_STRING_encode_aper
 
 #ifdef __cplusplus
 }

--- a/skeletons/INTEGER.c
+++ b/skeletons/INTEGER.c
@@ -1,5 +1,5 @@
-/*
- * Copyright (c) 2003-2019 Lev Walkin <vlm@lionet.info>.
+/*-
+ * Copyright (c) 2003-2014 Lev Walkin <vlm@lionet.info>.
  * All rights reserved.
  * Redistribution and modifications are permitted subject to BSD license.
  */
@@ -32,9 +32,13 @@ asn_TYPE_operation_t asn_OP_INTEGER = {
 #ifdef	ASN_DISABLE_PER_SUPPORT
 	0,
 	0,
+	0,
+	0,
 #else
 	INTEGER_decode_uper,	/* Unaligned PER decoder */
 	INTEGER_encode_uper,	/* Unaligned PER encoder */
+	INTEGER_decode_aper,	/* Aligned PER decoder */
+	INTEGER_encode_aper,	/* Aligned PER encoder */
 #endif	/* ASN_DISABLE_PER_SUPPORT */
 	INTEGER_random_fill,
 	0	/* Use generic outmost tag fetcher */
@@ -320,6 +324,8 @@ INTEGER_st_prealloc(INTEGER_t *st, int min_size) {
 static enum xer_pbd_rval
 INTEGER__xer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
                          const void *chunk_buf, size_t chunk_size) {
+    const asn_INTEGER_specifics_t *specs =
+        (const asn_INTEGER_specifics_t *)td->specifics;
     INTEGER_t *st = (INTEGER_t *)sptr;
 	intmax_t dec_value;
 	intmax_t hex_value = 0;
@@ -501,7 +507,9 @@ INTEGER__xer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
 		/* The last symbol encountered was a digit. */
         switch(asn_strtoimax_lim(dec_value_start, &dec_value_end, &dec_value)) {
         case ASN_STRTOX_OK:
-            if(dec_value >= LONG_MIN && dec_value <= LONG_MAX) {
+            if(specs && specs->field_unsigned && (uintmax_t) dec_value <= ULONG_MAX) {
+                break;
+            } else if(dec_value >= LONG_MIN && dec_value <= LONG_MAX) {
                 break;
             } else {
                 /*
@@ -563,7 +571,7 @@ INTEGER_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
                    int ilevel, enum xer_encoder_flags_e flags,
                    asn_app_consume_bytes_f *cb, void *app_key) {
     const INTEGER_t *st = (const INTEGER_t *)sptr;
-	asn_enc_rval_t er;
+	asn_enc_rval_t er = {0,0,0};
 
 	(void)ilevel;
 	(void)flags;
@@ -700,9 +708,9 @@ asn_enc_rval_t
 INTEGER_encode_uper(const asn_TYPE_descriptor_t *td,
                     const asn_per_constraints_t *constraints, const void *sptr,
                     asn_per_outp_t *po) {
-    const asn_INTEGER_specifics_t *specs =
-        (const asn_INTEGER_specifics_t *)td->specifics;
-    asn_enc_rval_t er;
+	const asn_INTEGER_specifics_t *specs =
+        	(const asn_INTEGER_specifics_t *)td->specifics;
+	asn_enc_rval_t er = {0,0,0};
 	const INTEGER_t *st = (const INTEGER_t *)sptr;
 	const uint8_t *buf;
 	const uint8_t *end;
@@ -769,12 +777,24 @@ INTEGER_encode_uper(const asn_TYPE_descriptor_t *td,
 		/* #11.5.6 -> #11.3 */
 		ASN_DEBUG("Encoding integer %ld (%lu) with range %d bits",
 			value, value - ct->lower_bound, ct->range_bits);
-        if(per_long_range_rebase(value, ct->lower_bound, ct->upper_bound, &v)) {
-            ASN__ENCODE_FAILED;
-        }
+	if(specs && specs->field_unsigned) {
+		if (  ((unsigned long)ct->lower_bound > (unsigned long)(ct->upper_bound)
+		   || ((unsigned long)value < (unsigned long)ct->lower_bound))
+		   || ((unsigned long)value > (unsigned long)ct->upper_bound)
+		) {
+			ASN_DEBUG("Value %lu to-be-encoded is outside the bounds [%lu, %lu]!",
+				value, ct->lower_bound, ct->upper_bound);
+			ASN__ENCODE_FAILED;
+		}
+ 		v = (unsigned long)value - (unsigned long)ct->lower_bound;
+ 	} else {
+ 		if(per_long_range_rebase(value, ct->lower_bound, ct->upper_bound, &v)) {
+ 			ASN__ENCODE_FAILED;
+ 		}
+	}
         if(uper_put_constrained_whole_number_u(po, v, ct->range_bits))
-            ASN__ENCODE_FAILED;
-		ASN__ENCODED_OK(er);
+		ASN__ENCODE_FAILED;
+	ASN__ENCODED_OK(er);
 	}
 
 	if(ct && ct->lower_bound) {
@@ -793,6 +813,301 @@ INTEGER_encode_uper(const asn_TYPE_descriptor_t *td,
 		buf += mayEncode;
         if(need_eom && uper_put_length(po, 0, 0)) ASN__ENCODE_FAILED;
     }
+
+	ASN__ENCODED_OK(er);
+}
+
+asn_dec_rval_t
+INTEGER_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
+                    const asn_TYPE_descriptor_t *td,
+                    const asn_per_constraints_t *constraints, void **sptr, asn_per_data_t *pd) {
+	const asn_INTEGER_specifics_t *specs = (const asn_INTEGER_specifics_t *)td->specifics;
+	asn_dec_rval_t rval = { RC_OK, 0 };
+	INTEGER_t *st = (INTEGER_t *)*sptr;
+	const asn_per_constraint_t *ct;
+	int repeat;
+
+	(void)opt_codec_ctx;
+
+	if(!st) {
+		st = (INTEGER_t *)(*sptr = CALLOC(1, sizeof(*st)));
+		if(!st) ASN__DECODE_FAILED;
+	}
+
+	if(!constraints) constraints = td->encoding_constraints.per_constraints;
+	ct = constraints ? &constraints->value : 0;
+
+	if(ct && ct->flags & APC_EXTENSIBLE) {
+		int inext = per_get_few_bits(pd, 1);
+		if(inext < 0) ASN__DECODE_STARVED;
+		if(inext) ct = 0;
+	}
+
+	FREEMEM(st->buf);
+	st->buf = 0;
+	st->size = 0;
+	if(ct) {
+		if(ct->flags & APC_SEMI_CONSTRAINED) {
+			st->buf = (uint8_t *)CALLOC(1, 2);
+			if(!st->buf) ASN__DECODE_FAILED;
+			st->size = 1;
+		} else if(ct->flags & APC_CONSTRAINED && ct->range_bits >= 0) {
+			size_t size = (ct->range_bits + 7) >> 3;
+			st->buf = (uint8_t *)MALLOC(1 + size + 1);
+			if(!st->buf) ASN__DECODE_FAILED;
+			st->size = size;
+		}
+	}
+
+	/* X.691, #12.2.2 */
+	if(ct && ct->flags != APC_UNCONSTRAINED) {
+		/* #10.5.6 */
+		ASN_DEBUG("Integer with range %d bits", ct->range_bits);
+		if(ct->range_bits >= 0) {
+			if (ct->range_bits > 16) {
+				int max_range_bytes = (ct->range_bits >> 3) +
+				                      (((ct->range_bits % 8) > 0) ? 1 : 0);
+				int length = 0, i;
+				long value = 0;
+
+				for (i = 1; ; i++) {
+					int upper = 1 << i;
+					if (upper >= max_range_bytes)
+						break;
+				}
+				ASN_DEBUG("Can encode %d (%d bytes) in %d bits", ct->range_bits,
+				          max_range_bytes, i);
+
+				if ((length = per_get_few_bits(pd, i)) < 0)
+					ASN__DECODE_FAILED;
+
+				/* X.691 #12.2.6 length determinant + lb (1) */
+				length += 1;
+				ASN_DEBUG("Got length %d", length);
+				if (aper_get_align(pd) != 0)
+					ASN__DECODE_FAILED;
+				while (length--) {
+					int buf = per_get_few_bits(pd, 8);
+					if (buf < 0)
+						ASN__DECODE_FAILED;
+					value += (((long)buf) << (8 * length));
+				}
+
+				value += ct->lower_bound;
+				if((specs && specs->field_unsigned)
+				        ? asn_uint642INTEGER(st, (unsigned long)value)
+				        : asn_int642INTEGER(st, value))
+					ASN__DECODE_FAILED;
+				ASN_DEBUG("Got value %ld + low %ld",
+				          value, ct->lower_bound);
+			} else {
+				long value = 0;
+				if (ct->range_bits < 8) {
+					value = per_get_few_bits(pd, ct->range_bits);
+					if(value < 0) ASN__DECODE_STARVED;
+				} else if (ct->range_bits == 8) {
+					if (aper_get_align(pd) < 0)
+						ASN__DECODE_FAILED;
+					value = per_get_few_bits(pd, ct->range_bits);
+					if(value < 0) ASN__DECODE_STARVED;
+				} else {
+					/* Align */
+					if (aper_get_align(pd) < 0)
+						ASN__DECODE_FAILED;
+					value = per_get_few_bits(pd, 16);
+					if(value < 0) ASN__DECODE_STARVED;
+				}
+				value += ct->lower_bound;
+				if((specs && specs->field_unsigned)
+				        ? asn_ulong2INTEGER(st, value)
+				        : asn_long2INTEGER(st, value))
+					ASN__DECODE_FAILED;
+				ASN_DEBUG("Got value %ld + low %ld",
+				          value, ct->lower_bound);
+			}
+			return rval;
+		} else {
+			ASN__DECODE_FAILED;
+		}
+	} else {
+		ASN_DEBUG("Decoding unconstrained integer %s", td->name);
+	}
+
+	/* X.691, #12.2.3, #12.2.4 */
+	do {
+		ssize_t len;
+		void *p;
+		int ret;
+
+		/* Get the PER length */
+		len = aper_get_length(pd, -1, -1, &repeat);
+		if(len < 0) ASN__DECODE_STARVED;
+
+		p = REALLOC(st->buf, st->size + len + 1);
+		if(!p) ASN__DECODE_FAILED;
+		st->buf = (uint8_t *)p;
+
+		ret = per_get_many_bits(pd, &st->buf[st->size], 0, 8 * len);
+		if(ret < 0) ASN__DECODE_STARVED;
+		st->size += len;
+	} while(repeat);
+	st->buf[st->size] = 0;	/* JIC */
+
+	/* #12.2.3 */
+	if(ct && ct->lower_bound) {
+		/*
+		 * TODO: replace by in-place arithmetics.
+		 */
+		long value;
+		if(asn_INTEGER2long(st, &value))
+			ASN__DECODE_FAILED;
+		if(asn_long2INTEGER(st, value + ct->lower_bound))
+			ASN__DECODE_FAILED;
+	}
+
+	return rval;
+}
+
+asn_enc_rval_t
+INTEGER_encode_aper(const asn_TYPE_descriptor_t *td,
+                    const asn_per_constraints_t *constraints,
+                    const void *sptr, asn_per_outp_t *po) {
+	const asn_INTEGER_specifics_t *specs = (const asn_INTEGER_specifics_t *)td->specifics;
+	asn_enc_rval_t er = {0,0,0};
+	const INTEGER_t *st = (const INTEGER_t *)sptr;
+	const uint8_t *buf;
+	const uint8_t *end;
+	const asn_per_constraint_t *ct;
+	long value = 0;
+
+	if(!st || st->size == 0) ASN__ENCODE_FAILED;
+
+	if(!constraints) constraints = td->encoding_constraints.per_constraints;
+	ct = constraints ? &constraints->value : 0;
+
+	er.encoded = 0;
+
+	if(ct) {
+		int inext = 0;
+		if(specs && specs->field_unsigned) {
+			unsigned long uval;
+			if(asn_INTEGER2ulong(st, &uval))
+				ASN__ENCODE_FAILED;
+			/* Check proper range */
+			if(ct->flags & APC_SEMI_CONSTRAINED) {
+				if(uval < (unsigned long)ct->lower_bound)
+					inext = 1;
+			} else if(ct->range_bits >= 0) {
+				if(uval < (unsigned long)ct->lower_bound
+				        || uval > (unsigned long)ct->upper_bound)
+					inext = 1;
+			}
+			ASN_DEBUG("Value %lu (%02x/%lu) lb %ld ub %ld %s",
+			          uval, st->buf[0], st->size,
+			          ct->lower_bound, ct->upper_bound,
+			          inext ? "ext" : "fix");
+			value = uval;
+		} else {
+			if(asn_INTEGER2long(st, &value)) ASN__ENCODE_FAILED;
+			/* Check proper range */
+			if(ct->flags & APC_SEMI_CONSTRAINED) {
+				if(value < ct->lower_bound)
+					inext = 1;
+			} else if(ct->range_bits >= 0) {
+				if(value < ct->lower_bound
+				        || value > ct->upper_bound)
+					inext = 1;
+			}
+			ASN_DEBUG("Value %lu (%02x/%lu) lb %ld ub %ld %s",
+			          value, st->buf[0], st->size,
+			          ct->lower_bound, ct->upper_bound,
+			          inext ? "ext" : "fix");
+		}
+		if(ct->flags & APC_EXTENSIBLE) {
+			if(per_put_few_bits(po, inext, 1))
+				ASN__ENCODE_FAILED;
+			if(inext) ct = 0;
+		} else if(inext) {
+			ASN__ENCODE_FAILED;
+		}
+	}
+
+	/* X.691, #12.2.2 */
+	if(ct && ct->range_bits >= 0) {
+		unsigned long v;
+
+		/* #10.5.6 */
+		ASN_DEBUG("Encoding integer %ld (%lu) with range %d bits",
+		          value, value - ct->lower_bound, ct->range_bits);
+
+		v = value - ct->lower_bound;
+
+		/* #12 <= 8 -> alignment ? */
+		if (ct->range_bits < 8) {
+			if(per_put_few_bits(po, 0x00 | v, ct->range_bits))
+				ASN__ENCODE_FAILED;
+		} else if (ct->range_bits == 8) {
+			if(aper_put_align(po) < 0)
+				ASN__ENCODE_FAILED;
+			if(per_put_few_bits(po, 0x00 | v, ct->range_bits))
+				ASN__ENCODE_FAILED;
+		} else if (ct->range_bits <= 16) {
+			/* Consume the bytes to align on octet */
+			if(aper_put_align(po) < 0)
+				ASN__ENCODE_FAILED;
+			if(per_put_few_bits(po, 0x0000 | v,
+			                    16))
+				ASN__ENCODE_FAILED;
+		} else {
+			/* TODO: extend to >64 bits */
+			int64_t v64 = v;
+			int i, j;
+			int max_range_bytes = (ct->range_bits >> 3) +
+			                      (((ct->range_bits % 8) > 0) ? 1 : 0);
+
+			for (i = 1; ; i++) {
+				int upper = 1 << i;
+				if (upper >= max_range_bytes)
+					break;
+			}
+
+			for (j = sizeof(int64_t) -1; j != 0; j--) {
+				int64_t val;
+				val = v64 >> (j * 8);
+				if (val != 0)
+					break;
+			}
+
+			/* Putting length in the minimum number of bits ex: 5 = 3bits */
+			if (per_put_few_bits(po, j, i))
+				ASN__ENCODE_FAILED;
+
+			/* Consume the bits to align on octet */
+			if (aper_put_align(po) < 0)
+				ASN__ENCODE_FAILED;
+			/* Put the value */
+			for (i = 0; i <= j; i++) {
+				if(per_put_few_bits(po, (v64 >> (8 * (j - i))) & 0xff, 8))
+					ASN__ENCODE_FAILED;
+			}
+		}
+		ASN__ENCODED_OK(er);
+	}
+
+	if(ct && ct->lower_bound) {
+		ASN_DEBUG("Adjust lower bound to %ld", ct->lower_bound);
+		/* TODO: adjust lower bound */
+		ASN__ENCODE_FAILED;
+	}
+
+	for(buf = st->buf, end = st->buf + st->size; buf < end;) {
+		ssize_t mayEncode = aper_put_length(po, -1, end - buf);
+		if(mayEncode < 0)
+			ASN__ENCODE_FAILED;
+		if(per_put_many_bits(po, buf, 8 * mayEncode))
+			ASN__ENCODE_FAILED;
+		buf += mayEncode;
+	}
 
 	ASN__ENCODED_OK(er);
 }
@@ -1024,6 +1339,87 @@ asn_ulong2INTEGER(INTEGER_t *st, unsigned long value) {
     return asn_imax2INTEGER(st, value);
 }
 
+
+int
+asn_uint642INTEGER(INTEGER_t *st, uint64_t value) {
+	uint8_t *buf;
+	uint8_t *end;
+	uint8_t *b;
+	int shr;
+
+	if(value <= INT64_MAX)
+		return asn_int642INTEGER(st, value);
+
+	buf = (uint8_t *)MALLOC(1 + sizeof(value));
+	if(!buf) return -1;
+
+	end = buf + (sizeof(value) + 1);
+	buf[0] = 0;
+	for(b = buf + 1, shr = (sizeof(value)-1)*8; b < end; shr -= 8, b++)
+		*b = (uint8_t)(value >> shr);
+
+	if(st->buf) FREEMEM(st->buf);
+	st->buf = buf;
+	st->size = 1 + sizeof(value);
+
+	return 0;
+}
+
+int
+asn_int642INTEGER(INTEGER_t *st, int64_t value) {
+	uint8_t *buf, *bp;
+	uint8_t *p;
+	uint8_t *pstart;
+	uint8_t *pend1;
+	int littleEndian = 1;	/* Run-time detection */
+	int add;
+
+	if(!st) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	buf = (uint8_t *)MALLOC(sizeof(value));
+	if(!buf) return -1;
+
+	if(*(char *)&littleEndian) {
+		pstart = (uint8_t *)&value + sizeof(value) - 1;
+		pend1 = (uint8_t *)&value;
+		add = -1;
+	} else {
+		pstart = (uint8_t *)&value;
+		pend1 = pstart + sizeof(value) - 1;
+		add = 1;
+	}
+
+	/*
+	 * If the contents octet consists of more than one octet,
+	 * then bits of the first octet and bit 8 of the second octet:
+	 * a) shall not all be ones; and
+	 * b) shall not all be zero.
+	 */
+	for(p = pstart; p != pend1; p += add) {
+		switch(*p) {
+		case 0x00: if((*(p+add) & 0x80) == 0)
+				continue;
+			break;
+		case 0xff: if((*(p+add) & 0x80))
+				continue;
+			break;
+		}
+		break;
+	}
+	/* Copy the integer body */
+	for(pstart = p, bp = buf, pend1 += add; p != pend1; p += add)
+		*bp++ = *p;
+
+	if(st->buf) FREEMEM(st->buf);
+	st->buf = buf;
+	st->size = bp - buf;
+
+	return 0;
+}
+
 /*
  * Parse the number in the given string until the given *end position,
  * returning the position after the last parsed character back using the
@@ -1032,71 +1428,64 @@ asn_ulong2INTEGER(INTEGER_t *st, unsigned long value) {
  */
 enum asn_strtox_result_e
 asn_strtoimax_lim(const char *str, const char **end, intmax_t *intp) {
-    int sign = 1;
-    intmax_t value;
+	int sign = 1;
+	intmax_t value;
 
-    const intmax_t asn1_intmax_max = ((~(uintmax_t)0) >> 1);
-    const intmax_t upper_boundary = asn1_intmax_max / 10;
-    intmax_t last_digit_max = asn1_intmax_max % 10;
+#define ASN1_INTMAX_MAX ((~(uintmax_t)0) >> 1)
+    const intmax_t upper_boundary = ASN1_INTMAX_MAX / 10;
+	intmax_t last_digit_max = ASN1_INTMAX_MAX % 10;
+#undef  ASN1_INTMAX_MAX
 
-    if(str >= *end) return ASN_STRTOX_ERROR_INVAL;
+	if(str >= *end) return ASN_STRTOX_ERROR_INVAL;
 
-    switch(*str) {
-    case '-':
-        last_digit_max++;
-        sign = -1;
-        /* FALL THROUGH */
-    case '+':
-        str++;
-        if(str >= *end) {
-            *end = str;
-            return ASN_STRTOX_EXPECT_MORE;
-        }
-    }
+	switch(*str) {
+	case '-':
+		last_digit_max++;
+		sign = -1;
+		/* FALL THROUGH */
+	case '+':
+		str++;
+		if(str >= *end) {
+			*end = str;
+			return ASN_STRTOX_EXPECT_MORE;
+		}
+	}
 
-    for(value = 0; str < (*end); str++) {
-        if(*str >= 0x30 && *str <= 0x39) {
-            int d = *str - '0';
-            if(value < upper_boundary) {
-                value = value * 10 + d;
-            } else if(value == upper_boundary) {
-                if(d <= last_digit_max) {
-                    if(sign > 0) {
-                        value = value * 10 + d;
-                    } else {
-                        sign = 1;
-                        value = -value * 10 - d;
-                    }
-                    str += 1;
-                    if(str < *end) {
-                        // If digits continue, we're guaranteed out of range.
-                        *end = str;
-                        if(*str >= 0x30 && *str <= 0x39) {
-                            return ASN_STRTOX_ERROR_RANGE;
-                        } else {
-                            *intp = sign * value;
-                            return ASN_STRTOX_EXTRA_DATA;
-                        }
-                    }
-                    break;
-                } else {
-                    *end = str;
-                    return ASN_STRTOX_ERROR_RANGE;
-                }
-            } else {
-                *end = str;
-                return ASN_STRTOX_ERROR_RANGE;
-            }
-        } else {
-            *end = str;
-            *intp = sign * value;
-            return ASN_STRTOX_EXTRA_DATA;
-        }
-    }
+	for(value = 0; str < (*end); str++) {
+		switch(*str) {
+		case 0x30: case 0x31: case 0x32: case 0x33: case 0x34:
+		case 0x35: case 0x36: case 0x37: case 0x38: case 0x39: {
+			int d = *str - '0';
+			if(value < upper_boundary) {
+				value = value * 10 + d;
+			} else if(value == upper_boundary) {
+				if(d <= last_digit_max) {
+					if(sign > 0) {
+						value = value * 10 + d;
+					} else {
+						sign = 1;
+						value = -value * 10 - d;
+					}
+				} else {
+					*end = str;
+					return ASN_STRTOX_ERROR_RANGE;
+				}
+			} else {
+				*end = str;
+				return ASN_STRTOX_ERROR_RANGE;
+			}
+		    }
+		    continue;
+		default:
+		    *end = str;
+		    *intp = sign * value;
+		    return ASN_STRTOX_EXTRA_DATA;
+		}
+	}
 
-    *end = str;
-    *intp = sign * value;
-    return ASN_STRTOX_OK;
+	*end = str;
+	*intp = sign * value;
+	return ASN_STRTOX_OK;
 }
 
 /*
@@ -1107,63 +1496,56 @@ asn_strtoimax_lim(const char *str, const char **end, intmax_t *intp) {
  */
 enum asn_strtox_result_e
 asn_strtoumax_lim(const char *str, const char **end, uintmax_t *uintp) {
-    uintmax_t value;
+	uintmax_t value;
 
-    const uintmax_t asn1_uintmax_max = ((~(uintmax_t)0));
-    const uintmax_t upper_boundary = asn1_uintmax_max / 10;
-    uintmax_t last_digit_max = asn1_uintmax_max % 10;
+#define ASN1_UINTMAX_MAX ((~(uintmax_t)0))
+    const uintmax_t upper_boundary = ASN1_UINTMAX_MAX / 10;
+    uintmax_t last_digit_max = ASN1_UINTMAX_MAX % 10;
+#undef ASN1_UINTMAX_MAX
 
     if(str >= *end) return ASN_STRTOX_ERROR_INVAL;
 
-    switch(*str) {
-    case '-':
+	switch(*str) {
+	case '-':
         return ASN_STRTOX_ERROR_INVAL;
-    case '+':
-        str++;
-        if(str >= *end) {
-            *end = str;
-            return ASN_STRTOX_EXPECT_MORE;
-        }
-    }
+	case '+':
+		str++;
+		if(str >= *end) {
+			*end = str;
+			return ASN_STRTOX_EXPECT_MORE;
+		}
+	}
 
-    for(value = 0; str < (*end); str++) {
-        if(*str >= 0x30 && *str <= 0x39) {
-            unsigned int d = *str - '0';
-            if(value < upper_boundary) {
-                value = value * 10 + d;
-            } else if(value == upper_boundary) {
-                if(d <= last_digit_max) {
+	for(value = 0; str < (*end); str++) {
+		switch(*str) {
+		case 0x30: case 0x31: case 0x32: case 0x33: case 0x34:
+		case 0x35: case 0x36: case 0x37: case 0x38: case 0x39: {
+			unsigned int d = *str - '0';
+			if(value < upper_boundary) {
+				value = value * 10 + d;
+			} else if(value == upper_boundary) {
+				if(d <= last_digit_max) {
                     value = value * 10 + d;
-                    str += 1;
-                    if(str < *end) {
-                        // If digits continue, we're guaranteed out of range.
-                        *end = str;
-                        if(*str >= 0x30 && *str <= 0x39) {
-                            return ASN_STRTOX_ERROR_RANGE;
-                        } else {
-                            *uintp = value;
-                            return ASN_STRTOX_EXTRA_DATA;
-                        }
-                    }
-                    break;
                 } else {
-                    *end = str;
-                    return ASN_STRTOX_ERROR_RANGE;
-                }
-            } else {
-                *end = str;
-                return ASN_STRTOX_ERROR_RANGE;
-            }
-        } else {
-            *end = str;
-            *uintp = value;
-            return ASN_STRTOX_EXTRA_DATA;
-        }
-    }
+					*end = str;
+					return ASN_STRTOX_ERROR_RANGE;
+				}
+			} else {
+				*end = str;
+				return ASN_STRTOX_ERROR_RANGE;
+			}
+		    }
+		    continue;
+		default:
+		    *end = str;
+		    *uintp = value;
+		    return ASN_STRTOX_EXTRA_DATA;
+		}
+	}
 
-    *end = str;
-    *uintp = value;
-    return ASN_STRTOX_OK;
+	*end = str;
+	*uintp = value;
+	return ASN_STRTOX_OK;
 }
 
 enum asn_strtox_result_e

--- a/skeletons/INTEGER.h
+++ b/skeletons/INTEGER.h
@@ -47,6 +47,8 @@ oer_type_decoder_f INTEGER_decode_oer;
 oer_type_encoder_f INTEGER_encode_oer;
 per_type_decoder_f INTEGER_decode_uper;
 per_type_encoder_f INTEGER_encode_uper;
+per_type_decoder_f INTEGER_decode_aper;
+per_type_encoder_f INTEGER_encode_aper;
 asn_random_fill_f  INTEGER_random_fill;
 
 /***********************************
@@ -73,6 +75,8 @@ int asn_INTEGER2long(const INTEGER_t *i, long *l);
 int asn_INTEGER2ulong(const INTEGER_t *i, unsigned long *l);
 int asn_long2INTEGER(INTEGER_t *i, long l);
 int asn_ulong2INTEGER(INTEGER_t *i, unsigned long l);
+int asn_int642INTEGER(INTEGER_t *i, int64_t l);
+int asn_uint642INTEGER(INTEGER_t *i, uint64_t l);
 
 /* A version of strtol/strtoimax(3) with nicer error reporting. */
 enum asn_strtox_result_e {

--- a/skeletons/NativeEnumerated.c
+++ b/skeletons/NativeEnumerated.c
@@ -36,9 +36,13 @@ asn_TYPE_operation_t asn_OP_NativeEnumerated = {
 #ifdef	ASN_DISABLE_PER_SUPPORT
 	0,
 	0,
+	0,
+	0,
 #else
 	NativeEnumerated_decode_uper,
 	NativeEnumerated_encode_uper,
+	NativeEnumerated_decode_aper,
+	NativeEnumerated_encode_aper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
 	NativeEnumerated_random_fill,
 	0	/* Use generic outmost tag fetcher */
@@ -62,7 +66,7 @@ NativeEnumerated_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
                             asn_app_consume_bytes_f *cb, void *app_key) {
     const asn_INTEGER_specifics_t *specs =
         (const asn_INTEGER_specifics_t *)td->specifics;
-    asn_enc_rval_t er;
+    asn_enc_rval_t er = {0,0,0};
     const long *native = (const long *)sptr;
     const asn_INTEGER_enum_map_t *el;
 
@@ -93,7 +97,7 @@ NativeEnumerated_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
     const asn_INTEGER_specifics_t *specs = td->specifics;
     asn_dec_rval_t rval = { RC_OK, 0 };
 	long *native = (long *)*sptr;
-	const asn_per_constraint_t *ct;
+	const asn_per_constraint_t *ct = NULL;
 	long value;
 
 	(void)opt_codec_ctx;
@@ -111,7 +115,7 @@ NativeEnumerated_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
 
 	ASN_DEBUG("Decoding %s as NativeEnumerated", td->name);
 
-	if(ct->flags & APC_EXTENSIBLE) {
+	if(ct && ct->flags & APC_EXTENSIBLE) {
 		int inext = per_get_few_bits(pd, 1);
 		if(inext < 0) ASN__DECODE_STARVED;
 		if(inext) ct = 0;
@@ -157,11 +161,11 @@ asn_enc_rval_t
 NativeEnumerated_encode_uper(const asn_TYPE_descriptor_t *td,
                              const asn_per_constraints_t *constraints,
                              const void *sptr, asn_per_outp_t *po) {
-    const asn_INTEGER_specifics_t *specs =
+	const asn_INTEGER_specifics_t *specs =
         (const asn_INTEGER_specifics_t *)td->specifics;
-    asn_enc_rval_t er;
+	asn_enc_rval_t er = {0,0,0};
 	long native, value;
-	const asn_per_constraint_t *ct;
+	const asn_per_constraint_t *ct = NULL;
 	int inext = 0;
 	asn_INTEGER_enum_map_t key;
 	const asn_INTEGER_enum_map_t *kf;
@@ -189,13 +193,13 @@ NativeEnumerated_encode_uper(const asn_TYPE_descriptor_t *td,
 	}
 	value = kf - specs->value2enum;
 
-	if(ct->range_bits >= 0) {
+	if(ct && ct->range_bits >= 0) {
 		int cmpWith = specs->extension
 				? specs->extension - 1 : specs->map_count;
 		if(value >= cmpWith)
 			inext = 1;
 	}
-	if(ct->flags & APC_EXTENSIBLE) {
+	if(ct && ct->flags & APC_EXTENSIBLE) {
 		if(per_put_few_bits(po, inext, 1))
 			ASN__ENCODE_FAILED;
 		if(inext) ct = 0;
@@ -224,3 +228,140 @@ NativeEnumerated_encode_uper(const asn_TYPE_descriptor_t *td,
 	ASN__ENCODED_OK(er);
 }
 
+asn_dec_rval_t
+NativeEnumerated_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
+                             const asn_TYPE_descriptor_t *td,
+                             const asn_per_constraints_t *constraints,
+                             void **sptr, asn_per_data_t *pd) {
+	const asn_INTEGER_specifics_t *specs = (const asn_INTEGER_specifics_t *)td->specifics;
+	asn_dec_rval_t rval = { RC_OK, 0 };
+	long *native = (long *)*sptr;
+	const asn_per_constraint_t *ct = NULL;
+	long value;
+
+	(void)opt_codec_ctx;
+
+	if(constraints) ct = &constraints->value;
+	else if(td->encoding_constraints.per_constraints)
+		ct = &td->encoding_constraints.per_constraints->value;
+	else ASN__DECODE_FAILED;	/* Mandatory! */
+	if(!specs) ASN__DECODE_FAILED;
+
+	if(!native) {
+		native = (long *)(*sptr = CALLOC(1, sizeof(*native)));
+		if(!native) ASN__DECODE_FAILED;
+	}
+
+	ASN_DEBUG("Decoding %s as NativeEnumerated", td->name);
+
+	if(ct && ct->flags & APC_EXTENSIBLE) {
+		int inext = per_get_few_bits(pd, 1);
+		if(inext < 0) ASN__DECODE_STARVED;
+		if(inext) ct = 0;
+	}
+
+	/* Deal with APER padding */
+	if(ct && ct->upper_bound >= 255) {
+		int padding = 0;
+		padding = (8 - (pd->moved % 8)) % 8;
+		ASN_DEBUG("For NativeEnumerated %s,offset= %lu Padding bits = %d", td->name, pd->moved, padding);
+		ASN_DEBUG("For NativeEnumerated %s, upper bound = %lu", td->name, ct->upper_bound);
+		if(padding > 0)
+			per_get_few_bits(pd, padding);
+	}
+
+	if(ct && ct->range_bits >= 0) {
+		value = per_get_few_bits(pd, ct->range_bits);
+		if(value < 0) ASN__DECODE_STARVED;
+		if(value >= (specs->extension
+		             ? specs->extension - 1 : specs->map_count))
+			ASN__DECODE_FAILED;
+	} else {
+		if(!specs->extension)
+			ASN__DECODE_FAILED;
+		/*
+		 * X.691, #10.6: normally small non-negative whole number;
+		 */
+		value = uper_get_nsnnwn(pd);
+		if(value < 0) ASN__DECODE_STARVED;
+		value += specs->extension - 1;
+		if(value >= specs->map_count)
+			ASN__DECODE_FAILED;
+	}
+
+	*native = specs->value2enum[value].nat_value;
+	ASN_DEBUG("Decoded %s = %ld", td->name, *native);
+
+	return rval;
+}
+
+asn_enc_rval_t
+NativeEnumerated_encode_aper(const asn_TYPE_descriptor_t *td,
+                             const asn_per_constraints_t *constraints,
+                             const void *sptr, asn_per_outp_t *po) {
+	const asn_INTEGER_specifics_t *specs = (const asn_INTEGER_specifics_t *)td->specifics;
+	asn_enc_rval_t er = {0,0,0};
+	long native, value;
+	const asn_per_constraint_t *ct = NULL;
+	int inext = 0;
+	asn_INTEGER_enum_map_t key;
+	asn_INTEGER_enum_map_t *kf;
+
+	if(!sptr) ASN__ENCODE_FAILED;
+	if(!specs) ASN__ENCODE_FAILED;
+
+	if(constraints) ct = &constraints->value;
+	else if(td->encoding_constraints.per_constraints)
+		ct = &td->encoding_constraints.per_constraints->value;
+	else ASN__ENCODE_FAILED;        /* Mandatory! */
+
+	ASN_DEBUG("Encoding %s as NativeEnumerated", td->name);
+
+	er.encoded = 0;
+
+	native = *(const long *)sptr;
+	if(native < 0) ASN__ENCODE_FAILED;
+
+	key.nat_value = native;
+	kf = bsearch(&key, specs->value2enum, specs->map_count,
+	             sizeof(key), NativeEnumerated__compar_value2enum);
+	if(!kf) {
+		ASN_DEBUG("No element corresponds to %ld", native);
+		ASN__ENCODE_FAILED;
+	}
+	value = kf - specs->value2enum;
+
+	if(ct && ct->range_bits >= 0) {
+		int cmpWith = specs->extension
+		              ? specs->extension - 1 : specs->map_count;
+		if(value >= cmpWith)
+			inext = 1;
+	}
+	if(ct && ct->flags & APC_EXTENSIBLE) {
+		if(per_put_few_bits(po, inext, 1))
+			ASN__ENCODE_FAILED;
+		if(inext) ct = 0;
+	} else if(inext) {
+		ASN__ENCODE_FAILED;
+	}
+
+	if(ct && ct->range_bits >= 0) {
+		if(per_put_few_bits(po, value, ct->range_bits))
+			ASN__ENCODE_FAILED;
+		ASN__ENCODED_OK(er);
+	}
+
+	if(!specs->extension)
+		ASN__ENCODE_FAILED;
+
+	/*
+	 * X.691, #10.6: normally small non-negative whole number;
+	 */
+	ASN_DEBUG("value = %ld, ext = %d, inext = %d, res = %ld",
+	          value, specs->extension, inext,
+	          value - (inext ? (specs->extension - 1) : 0));
+	if(uper_put_nsnnwn(po, value - (inext ? (specs->extension - 1) : 0)))
+		ASN__ENCODE_FAILED;
+
+	ASN__ENCODED_OK(er);
+}

--- a/skeletons/NativeEnumerated.h
+++ b/skeletons/NativeEnumerated.h
@@ -26,6 +26,8 @@ oer_type_decoder_f NativeEnumerated_decode_oer;
 oer_type_encoder_f NativeEnumerated_encode_oer;
 per_type_decoder_f NativeEnumerated_decode_uper;
 per_type_encoder_f NativeEnumerated_encode_uper;
+per_type_decoder_f NativeEnumerated_decode_aper;
+per_type_encoder_f NativeEnumerated_encode_aper;
 
 #define NativeEnumerated_free       NativeInteger_free
 #define NativeEnumerated_print      NativeInteger_print

--- a/skeletons/NativeInteger.c
+++ b/skeletons/NativeInteger.c
@@ -37,9 +37,13 @@ asn_TYPE_operation_t asn_OP_NativeInteger = {
 #ifdef	ASN_DISABLE_PER_SUPPORT
 	0,
 	0,
+	0,
+	0,
 #else
 	NativeInteger_decode_uper,	/* Unaligned PER decoder */
 	NativeInteger_encode_uper,	/* Unaligned PER encoder */
+	NativeInteger_decode_aper,	/* Aligned PER decoder */
+	NativeInteger_encode_aper,	/* Aligned PER encoder */
 #endif	/* ASN_DISABLE_PER_SUPPORT */
 	NativeInteger_random_fill,
 	0	/* Use generic outmost tag fetcher */
@@ -150,8 +154,8 @@ asn_enc_rval_t
 NativeInteger_encode_der(const asn_TYPE_descriptor_t *sd, const void *ptr,
                          int tag_mode, ber_tlv_tag_t tag,
                          asn_app_consume_bytes_f *cb, void *app_key) {
-    unsigned long native = *(const unsigned long *)ptr; /* Disable sign ext. */
-    asn_enc_rval_t erval;
+	unsigned long native = *(const unsigned long *)ptr; /* Disable sign ext. */
+	asn_enc_rval_t erval = {0,0,0};
 	INTEGER_t tmp;
 
 #ifdef	WORDS_BIGENDIAN		/* Opportunistic optimization */
@@ -232,7 +236,7 @@ NativeInteger_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
     const asn_INTEGER_specifics_t *specs =
         (const asn_INTEGER_specifics_t *)td->specifics;
     char scratch[32];	/* Enough for 64-bit int */
-	asn_enc_rval_t er;
+	asn_enc_rval_t er = {0,0,0};
 	const long *native = (const long *)sptr;
 
 	(void)ilevel;
@@ -295,7 +299,7 @@ NativeInteger_encode_uper(const asn_TYPE_descriptor_t *td,
                           const void *sptr, asn_per_outp_t *po) {
     const asn_INTEGER_specifics_t *specs =
         (const asn_INTEGER_specifics_t *)td->specifics;
-    asn_enc_rval_t er;
+    asn_enc_rval_t er = {0,0,0};
 	long native;
 	INTEGER_t tmpint;
 
@@ -311,6 +315,68 @@ NativeInteger_encode_uper(const asn_TYPE_descriptor_t *td,
 		: asn_long2INTEGER(&tmpint, native))
 		ASN__ENCODE_FAILED;
 	er = INTEGER_encode_uper(td, constraints, &tmpint, po);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_INTEGER, &tmpint);
+	return er;
+}
+
+asn_dec_rval_t
+NativeInteger_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
+                          const asn_TYPE_descriptor_t *td,
+                          const asn_per_constraints_t *constraints, void **sptr, asn_per_data_t *pd) {
+
+	const asn_INTEGER_specifics_t *specs = (const asn_INTEGER_specifics_t *)td->specifics;
+	asn_dec_rval_t rval;
+	long *native = (long *)*sptr;
+	INTEGER_t tmpint;
+	void *tmpintptr = &tmpint;
+
+	(void)opt_codec_ctx;
+	ASN_DEBUG("Decoding NativeInteger %s (APER)", td->name);
+
+	if(!native) {
+		native = (long *)(*sptr = CALLOC(1, sizeof(*native)));
+		if(!native) ASN__DECODE_FAILED;
+	}
+
+	memset(&tmpint, 0, sizeof tmpint);
+	rval = INTEGER_decode_aper(opt_codec_ctx, td, constraints,
+	                           &tmpintptr, pd);
+	if(rval.code == RC_OK) {
+		if((specs&&specs->field_unsigned)
+		        ? asn_INTEGER2ulong(&tmpint, (unsigned long *)native)
+		        : asn_INTEGER2long(&tmpint, native))
+			rval.code = RC_FAIL;
+		else
+			ASN_DEBUG("NativeInteger %s got value %ld",
+			          td->name, *native);
+	}
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_INTEGER, &tmpint);
+
+	return rval;
+}
+
+asn_enc_rval_t
+NativeInteger_encode_aper(const asn_TYPE_descriptor_t *td,
+                          const asn_per_constraints_t *constraints,
+                          const void *sptr, asn_per_outp_t *po) {
+
+	const asn_INTEGER_specifics_t *specs = (const asn_INTEGER_specifics_t *)td->specifics;
+	asn_enc_rval_t er = {0,0,0};
+	long native;
+	INTEGER_t tmpint;
+
+	if(!sptr) ASN__ENCODE_FAILED;
+
+	native = *(const long *)sptr;
+
+	ASN_DEBUG("Encoding NativeInteger %s %ld (APER)", td->name, native);
+
+	memset(&tmpint, 0, sizeof(tmpint));
+	if((specs&&specs->field_unsigned)
+	        ? asn_ulong2INTEGER(&tmpint, (unsigned long)native)
+	        : asn_long2INTEGER(&tmpint, native))
+		ASN__ENCODE_FAILED;
+	er = INTEGER_encode_aper(td, constraints, &tmpint, po);
 	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_INTEGER, &tmpint);
 	return er;
 }

--- a/skeletons/NativeInteger.h
+++ b/skeletons/NativeInteger.h
@@ -33,6 +33,8 @@ oer_type_decoder_f NativeInteger_decode_oer;
 oer_type_encoder_f NativeInteger_encode_oer;
 per_type_decoder_f NativeInteger_decode_uper;
 per_type_encoder_f NativeInteger_encode_uper;
+per_type_decoder_f NativeInteger_decode_aper;
+per_type_encoder_f NativeInteger_encode_aper;
 asn_random_fill_f  NativeInteger_random_fill;
 
 #define NativeInteger_constraint  asn_generic_no_constraint

--- a/skeletons/OCTET_STRING.c
+++ b/skeletons/OCTET_STRING.c
@@ -38,9 +38,13 @@ asn_TYPE_operation_t asn_OP_OCTET_STRING = {
 #ifdef	ASN_DISABLE_PER_SUPPORT
 	0,
 	0,
+	0,
+	0,
 #else
 	OCTET_STRING_decode_uper,	/* Unaligned PER decoder */
 	OCTET_STRING_encode_uper,	/* Unaligned PER encoder */
+	OCTET_STRING_decode_aper,	/* Aligned PER decoder */
+	OCTET_STRING_encode_aper,	/* Aligned PER encoder */
 #endif	/* ASN_DISABLE_PER_SUPPORT */
 	OCTET_STRING_random_fill,
 	0	/* Use generic outmost tag fetcher */
@@ -153,7 +157,7 @@ OS__add_stack_el(struct _stack *st) {
 		nel = (struct _stack_el *)CALLOC(1, sizeof(struct _stack_el));
 		if(nel == NULL)
 			return NULL;
-	
+
 		if(st->tail) {
 			/* Increase a subcontainment depth */
 			nel->cont_level = st->tail->cont_level + 1;
@@ -535,7 +539,7 @@ asn_enc_rval_t
 OCTET_STRING_encode_der(const asn_TYPE_descriptor_t *td, const void *sptr,
                         int tag_mode, ber_tlv_tag_t tag,
                         asn_app_consume_bytes_f *cb, void *app_key) {
-    asn_enc_rval_t er;
+    asn_enc_rval_t er = { 0, 0, 0 };
 	const asn_OCTET_STRING_specifics_t *specs = td->specifics
 				? (const asn_OCTET_STRING_specifics_t *)td->specifics
 				: &asn_SPC_OCTET_STRING_specs;
@@ -599,7 +603,7 @@ OCTET_STRING_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
                         asn_app_consume_bytes_f *cb, void *app_key) {
     const char * const h2c = "0123456789ABCDEF";
 	const OCTET_STRING_t *st = (const OCTET_STRING_t *)sptr;
-	asn_enc_rval_t er;
+	asn_enc_rval_t er = { 0, 0, 0 };
 	char scratch[16 * 3 + 4];
 	char *p = scratch;
 	uint8_t *buf;
@@ -741,7 +745,7 @@ OCTET_STRING__handle_control_chars(void *struct_ptr, const void *chunk_buf, size
 			return 0;
 		}
 	}
-	
+
 	return -1;	/* No, it's not */
 }
 
@@ -749,8 +753,8 @@ asn_enc_rval_t
 OCTET_STRING_encode_xer_utf8(const asn_TYPE_descriptor_t *td, const void *sptr,
                              int ilevel, enum xer_encoder_flags_e flags,
                              asn_app_consume_bytes_f *cb, void *app_key) {
-    const OCTET_STRING_t *st = (const OCTET_STRING_t *)sptr;
-	asn_enc_rval_t er;
+	const OCTET_STRING_t *st = (const OCTET_STRING_t *)sptr;
+	asn_enc_rval_t er = { 0, 0, 0 };
 	uint8_t *buf, *end;
 	uint8_t *ss;	/* Sequence start */
 	ssize_t encoded_len = 0;
@@ -1641,6 +1645,370 @@ OCTET_STRING_encode_uper(const asn_TYPE_descriptor_t *td,
     } while(size_in_units);
 
     ASN__ENCODED_OK(er);
+}
+
+asn_dec_rval_t
+OCTET_STRING_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
+                         const asn_TYPE_descriptor_t *td,
+                         const asn_per_constraints_t *constraints,
+                         void **sptr, asn_per_data_t *pd) {
+
+	const asn_OCTET_STRING_specifics_t *specs = td->specifics
+		? (const asn_OCTET_STRING_specifics_t *)td->specifics
+		: &asn_SPC_OCTET_STRING_specs;
+	const asn_per_constraints_t *pc = constraints ? constraints
+				: td->encoding_constraints.per_constraints;
+	const asn_per_constraint_t *cval;
+	const asn_per_constraint_t *csiz;
+	asn_dec_rval_t rval = { RC_OK, 0 };
+	BIT_STRING_t *st = (BIT_STRING_t *)*sptr;
+	ssize_t consumed_myself = 0;
+	int repeat;
+	enum {
+		OS__BPC_BIT	= 0,
+		OS__BPC_CHAR	= 1,
+		OS__BPC_U16	= 2,
+		OS__BPC_U32	= 4
+	} bpc;	/* Bytes per character */
+	unsigned int unit_bits;
+	unsigned int canonical_unit_bits;
+
+	(void)opt_codec_ctx;
+
+	if(pc) {
+		cval = &pc->value;
+		csiz = &pc->size;
+	} else {
+		cval = &asn_DEF_OCTET_STRING_constraints.value;
+		csiz = &asn_DEF_OCTET_STRING_constraints.size;
+	}
+
+	switch(specs->subvariant) {
+	default:
+/* 	case ASN_OSUBV_ANY:
+		ASN_DEBUG("Unrecognized subvariant %d", specs->subvariant);
+		RETURN(RC_FAIL);
+*/
+	case ASN_OSUBV_BIT:
+		canonical_unit_bits = unit_bits = 1;
+		bpc = OS__BPC_BIT;
+		break;
+	case ASN_OSUBV_ANY:
+	case ASN_OSUBV_STR:
+		canonical_unit_bits = unit_bits = 8;
+/* 		if(cval->flags & APC_CONSTRAINED)
+			unit_bits = cval->range_bits;
+*/
+		bpc = OS__BPC_CHAR;
+		break;
+	case ASN_OSUBV_U16:
+		canonical_unit_bits = unit_bits = 16;
+		if(cval->flags & APC_CONSTRAINED)
+			unit_bits = cval->range_bits;
+		bpc = OS__BPC_U16;
+		break;
+	case ASN_OSUBV_U32:
+		canonical_unit_bits = unit_bits = 32;
+		if(cval->flags & APC_CONSTRAINED)
+			unit_bits = cval->range_bits;
+		bpc = OS__BPC_U32;
+		break;
+	}
+
+	/*
+	 * Allocate the string.
+	 */
+	if(!st) {
+		st = (BIT_STRING_t *)(*sptr = CALLOC(1, specs->struct_size));
+		if(!st) RETURN(RC_FAIL);
+	}
+
+	ASN_DEBUG("PER Decoding %s size %ld .. %ld bits %d",
+		csiz->flags & APC_EXTENSIBLE ? "extensible" : "non-extensible",
+		csiz->lower_bound, csiz->upper_bound, csiz->effective_bits);
+
+	if(csiz->flags & APC_EXTENSIBLE) {
+		int inext = per_get_few_bits(pd, 1);
+		if(inext < 0) RETURN(RC_WMORE);
+		if(inext) {
+			csiz = &asn_DEF_OCTET_STRING_constraints.size;
+			cval = &asn_DEF_OCTET_STRING_constraints.value;
+			unit_bits = canonical_unit_bits;
+		}
+	}
+
+	if(csiz->effective_bits >= 0) {
+		FREEMEM(st->buf);
+		if(bpc) {
+			st->size = csiz->upper_bound * bpc;
+		} else {
+			st->size = (csiz->upper_bound + 7) >> 3;
+		}
+		st->buf = (uint8_t *)MALLOC(st->size + 1);
+		if(!st->buf) { st->size = 0; RETURN(RC_FAIL); }
+	}
+
+	/* X.691, #16.5: zero-length encoding */
+	/* X.691, #16.6: short fixed length encoding (up to 2 octets) */
+	/* X.691, #16.7: long fixed length encoding (up to 64K octets) */
+	if(csiz->effective_bits == 0) {
+		int ret;
+		if (st->size > 2) { /* X.691 #16 NOTE 1 */
+			if (aper_get_align(pd) < 0)
+				RETURN(RC_FAIL);
+		}
+		if(bpc) {
+			ASN_DEBUG("Decoding OCTET STRING size %ld",
+				csiz->upper_bound);
+			ret = OCTET_STRING_per_get_characters(pd, st->buf,
+				csiz->upper_bound, bpc, unit_bits,
+				cval->lower_bound, cval->upper_bound, pc);
+			if(ret > 0) RETURN(RC_FAIL);
+		} else {
+			ASN_DEBUG("Decoding BIT STRING size %ld",
+				csiz->upper_bound);
+			ret = per_get_many_bits(pd, st->buf, 0,
+					    unit_bits * csiz->upper_bound);
+		}
+		if(ret < 0) RETURN(RC_WMORE);
+		consumed_myself += unit_bits * csiz->upper_bound;
+		st->buf[st->size] = 0;
+		if(bpc == 0) {
+			int ubs = (csiz->upper_bound & 0x7);
+			st->bits_unused = ubs ? 8 - ubs : 0;
+		}
+		RETURN(RC_OK);
+	}
+
+	st->size = 0;
+	do {
+		ssize_t raw_len;
+		ssize_t len_bytes;
+		ssize_t len_bits;
+		void *p;
+		int ret;
+
+		/* Get the PER length */
+		if (csiz->upper_bound - csiz->lower_bound == 0)
+			/* Indefinite length case */
+			raw_len = aper_get_length(pd, -1, csiz->effective_bits, &repeat);
+		else
+			raw_len = aper_get_length(pd, csiz->upper_bound - csiz->lower_bound + 1, csiz->effective_bits, &repeat);
+		repeat = 0;
+		if(raw_len < 0) RETURN(RC_WMORE);
+		raw_len += csiz->lower_bound;
+
+		ASN_DEBUG("Got PER length eb %ld, len %ld, %s (%s)",
+			(long)csiz->effective_bits, (long)raw_len,
+			repeat ? "repeat" : "once", td->name);
+
+		if (raw_len > 2) { /* X.691 #16 NOTE 1 */
+			if (aper_get_align(pd) < 0)
+				RETURN(RC_FAIL);
+		}
+
+		if(bpc) {
+			len_bytes = raw_len * bpc;
+			len_bits = len_bytes * unit_bits;
+		} else {
+			len_bits = raw_len;
+			len_bytes = (len_bits + 7) >> 3;
+			if(len_bits & 0x7)
+				st->bits_unused = 8 - (len_bits & 0x7);
+			/* len_bits be multiple of 16K if repeat is set */
+		}
+		p = REALLOC(st->buf, st->size + len_bytes + 1);
+		if(!p) RETURN(RC_FAIL);
+		st->buf = (uint8_t *)p;
+
+		if(bpc) {
+			ret = OCTET_STRING_per_get_characters(pd,
+				&st->buf[st->size], raw_len, bpc, unit_bits,
+				cval->lower_bound, cval->upper_bound, pc);
+			if(ret > 0) RETURN(RC_FAIL);
+		} else {
+			ret = per_get_many_bits(pd, &st->buf[st->size],
+				0, len_bits);
+		}
+		if(ret < 0) RETURN(RC_WMORE);
+		st->size += len_bytes;
+	} while(repeat);
+	st->buf[st->size] = 0;	/* nul-terminate */
+
+	return rval;
+}
+
+asn_enc_rval_t
+OCTET_STRING_encode_aper(const asn_TYPE_descriptor_t *td,
+                         const asn_per_constraints_t *constraints,
+                         const void *sptr, asn_per_outp_t *po) {
+
+	const asn_OCTET_STRING_specifics_t *specs = td->specifics
+		? (const asn_OCTET_STRING_specifics_t *)td->specifics
+		: &asn_SPC_OCTET_STRING_specs;
+	const asn_per_constraints_t *pc = constraints ? constraints
+	: td->encoding_constraints.per_constraints;
+	const asn_per_constraint_t *cval;
+	const asn_per_constraint_t *csiz;
+	const BIT_STRING_t *st = (const BIT_STRING_t *)sptr;
+	asn_enc_rval_t er = { 0, 0, 0 };
+	int inext = 0;          /* Lies not within extension root */
+	unsigned int unit_bits;
+	unsigned int canonical_unit_bits;
+	unsigned int sizeinunits;
+	const uint8_t *buf;
+	int ret;
+	enum {
+		OS__BPC_BIT     = 0,
+		OS__BPC_CHAR    = 1,
+		OS__BPC_U16     = 2,
+		OS__BPC_U32     = 4
+	} bpc;  /* Bytes per character */
+	int ct_extensible;
+
+	if(!st || (!st->buf && st->size))
+		ASN__ENCODE_FAILED;
+
+	if(pc) {
+		cval = &pc->value;
+		csiz = &pc->size;
+	} else {
+		cval = &asn_DEF_OCTET_STRING_constraints.value;
+		csiz = &asn_DEF_OCTET_STRING_constraints.size;
+	}
+	ct_extensible = csiz->flags & APC_EXTENSIBLE;
+
+	switch(specs->subvariant) {
+		default:
+			/*         case ASN_OSUBV_ANY:
+			                 ASN__ENCODE_FAILED;
+			*/
+		case ASN_OSUBV_BIT:
+			canonical_unit_bits = unit_bits = 1;
+			bpc = OS__BPC_BIT;
+			sizeinunits = st->size * 8 - (st->bits_unused & 0x07);
+			ASN_DEBUG("BIT STRING of %d bytes",
+								sizeinunits);
+		break;
+        case ASN_OSUBV_ANY:
+	case ASN_OSUBV_STR:
+		canonical_unit_bits = unit_bits = 8;
+/* 		if(cval->flags & APC_CONSTRAINED)
+			unit_bits = 8;
+*/
+		bpc = OS__BPC_CHAR;
+		sizeinunits = st->size;
+		break;
+	case ASN_OSUBV_U16:
+		canonical_unit_bits = unit_bits = 16;
+		if(cval->flags & APC_CONSTRAINED)
+			unit_bits = cval->range_bits;
+		bpc = OS__BPC_U16;
+		sizeinunits = st->size / 2;
+		break;
+	case ASN_OSUBV_U32:
+		canonical_unit_bits = unit_bits = 32;
+		if(cval->flags & APC_CONSTRAINED)
+			unit_bits = cval->range_bits;
+		bpc = OS__BPC_U32;
+		sizeinunits = st->size / 4;
+		break;
+	}
+
+	ASN_DEBUG("Encoding %s into %d units of %d bits"
+		" (%ld..%ld, effective %d)%s",
+		td->name, sizeinunits, unit_bits,
+		csiz->lower_bound, csiz->upper_bound,
+		csiz->effective_bits, ct_extensible ? " EXT" : "");
+
+	/* Figure out wheter size lies within PER visible constraint */
+
+	if(csiz->effective_bits >= 0) {
+		if((int)sizeinunits < csiz->lower_bound
+		|| (int)sizeinunits > csiz->upper_bound) {
+			if(ct_extensible) {
+				cval = &asn_DEF_OCTET_STRING_constraints.value;
+				csiz = &asn_DEF_OCTET_STRING_constraints.size;
+				unit_bits = canonical_unit_bits;
+				inext = 1;
+			} else
+				ASN__ENCODE_FAILED;
+		}
+	} else {
+		inext = 0;
+	}
+
+
+	if(ct_extensible) {
+		/* Declare whether length is [not] within extension root */
+		if(per_put_few_bits(po, inext, 1))
+			ASN__ENCODE_FAILED;
+	}
+
+	/* X.691, #16.5: zero-length encoding */
+	/* X.691, #16.6: short fixed length encoding (up to 2 octets) */
+	/* X.691, #16.7: long fixed length encoding (up to 64K octets) */
+	if(csiz->effective_bits >= 0) {
+		ASN_DEBUG("Encoding %lu bytes (%ld), length in %d bits",
+				st->size, sizeinunits - csiz->lower_bound,
+				csiz->effective_bits);
+		if (csiz->effective_bits > 0) {
+		        ret = aper_put_length(po, csiz->upper_bound - csiz->lower_bound + 1, sizeinunits - csiz->lower_bound);
+		        if(ret) ASN__ENCODE_FAILED;
+		}
+		/* EB MOD
+                   AFAIU if lb != ub it is aligned whatever the number of bits */
+		if ((st->size > 2) || (csiz->lower_bound != csiz->upper_bound)) { /* X.691 #16.11 */
+			if (aper_put_align(po) < 0)
+				ASN__ENCODE_FAILED;
+		}
+		if(bpc) {
+			ret = OCTET_STRING_per_put_characters(po, st->buf,
+				sizeinunits, bpc, unit_bits,
+				cval->lower_bound, cval->upper_bound, pc);
+		} else {
+			ret = per_put_many_bits(po, st->buf,
+				sizeinunits * unit_bits);
+		}
+		if(ret) ASN__ENCODE_FAILED;
+		ASN__ENCODED_OK(er);
+	}
+
+	ASN_DEBUG("Encoding %lu bytes", st->size);
+
+	if(sizeinunits == 0) {
+		if(aper_put_length(po, -1, 0))
+			ASN__ENCODE_FAILED;
+		ASN__ENCODED_OK(er);
+	}
+
+	buf = st->buf;
+	while(sizeinunits) {
+		ssize_t maySave = aper_put_length(po, -1, sizeinunits);
+
+		if(maySave < 0) ASN__ENCODE_FAILED;
+
+		ASN_DEBUG("Encoding %ld of %ld",
+			(long)maySave, (long)sizeinunits);
+
+		if(bpc) {
+			ret = OCTET_STRING_per_put_characters(po, buf,
+				maySave, bpc, unit_bits,
+				cval->lower_bound, cval->upper_bound, pc);
+		} else {
+			ret = per_put_many_bits(po, buf, maySave * unit_bits);
+		}
+		if(ret) ASN__ENCODE_FAILED;
+
+		if(bpc)
+			buf += maySave * bpc;
+		else
+			buf += maySave >> 3;
+		sizeinunits -= maySave;
+		assert(!(maySave & 0x07) || !sizeinunits);
+	}
+
+	ASN__ENCODED_OK(er);
 }
 
 #endif  /* ASN_DISABLE_PER_SUPPORT */

--- a/skeletons/OCTET_STRING.h
+++ b/skeletons/OCTET_STRING.h
@@ -36,6 +36,8 @@ oer_type_decoder_f OCTET_STRING_decode_oer;
 oer_type_encoder_f OCTET_STRING_encode_oer;
 per_type_decoder_f OCTET_STRING_decode_uper;
 per_type_encoder_f OCTET_STRING_encode_uper;
+per_type_decoder_f OCTET_STRING_decode_aper;
+per_type_encoder_f OCTET_STRING_encode_aper;
 asn_random_fill_f  OCTET_STRING_random_fill;
 
 #define OCTET_STRING_constraint  asn_generic_no_constraint

--- a/skeletons/OPEN_TYPE.h
+++ b/skeletons/OPEN_TYPE.h
@@ -19,7 +19,10 @@ extern "C" {
 #define OPEN_TYPE_encode_der CHOICE_encode_der
 #define OPEN_TYPE_decode_xer NULL
 #define OPEN_TYPE_encode_xer CHOICE_encode_xer
+#define OPEN_TYPE_decode_oer NULL
+#define OPEN_TYPE_encode_oer CHOICE_encode_oer
 #define OPEN_TYPE_decode_uper NULL
+#define OPEN_TYPE_decode_aper NULL
 
 extern asn_TYPE_operation_t asn_OP_OPEN_TYPE;
 
@@ -51,7 +54,18 @@ asn_dec_rval_t OPEN_TYPE_uper_get(const asn_codec_ctx_t *opt_codec_ctx,
                                   const asn_TYPE_member_t *element,
                                   asn_per_data_t *pd);
 
+asn_dec_rval_t OPEN_TYPE_aper_get(const asn_codec_ctx_t *opt_codec_ctx,
+                                  const asn_TYPE_descriptor_t *parent_type,
+                                  void *parent_structure,
+                                  const asn_TYPE_member_t *element,
+                                  asn_per_data_t *pd);
+
 asn_enc_rval_t OPEN_TYPE_encode_uper(
+    const asn_TYPE_descriptor_t *type_descriptor,
+    const asn_per_constraints_t *constraints, const void *struct_ptr,
+    asn_per_outp_t *per_output);
+
+asn_enc_rval_t OPEN_TYPE_encode_aper(
     const asn_TYPE_descriptor_t *type_descriptor,
     const asn_per_constraints_t *constraints, const void *struct_ptr,
     asn_per_outp_t *per_output);

--- a/skeletons/PrintableString.c
+++ b/skeletons/PrintableString.c
@@ -65,9 +65,13 @@ asn_TYPE_operation_t asn_OP_PrintableString = {
 #ifdef	ASN_DISABLE_PER_SUPPORT
 	0,
 	0,
+	0,
+	0,
 #else
 	OCTET_STRING_decode_uper,
 	OCTET_STRING_encode_uper,
+	OCTET_STRING_decode_aper,
+	OCTET_STRING_encode_aper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
 	OCTET_STRING_random_fill,
 	0	/* Use generic outmost tag fetcher */

--- a/skeletons/PrintableString.h
+++ b/skeletons/PrintableString.h
@@ -27,6 +27,8 @@ asn_constr_check_f PrintableString_constraint;
 #define PrintableString_encode_xer      OCTET_STRING_encode_xer_utf8
 #define PrintableString_decode_uper     OCTET_STRING_decode_uper
 #define PrintableString_encode_uper     OCTET_STRING_encode_uper
+#define PrintableString_decode_aper     OCTET_STRING_decode_aper
+#define PrintableString_encode_aper     OCTET_STRING_encode_aper
 
 #ifdef __cplusplus
 }

--- a/skeletons/asn_application.c
+++ b/skeletons/asn_application.c
@@ -134,7 +134,7 @@ asn_encode(const asn_codec_ctx_t *opt_codec_ctx,
            enum asn_transfer_syntax syntax, const asn_TYPE_descriptor_t *td,
            const void *sptr, asn_app_consume_bytes_f *callback, void *callback_key) {
     struct callback_failure_catch_key cb_key;
-    asn_enc_rval_t er;
+    asn_enc_rval_t er = {0,0,0};
 
     if(!callback) {
         errno = EINVAL;
@@ -162,7 +162,7 @@ asn_encode_to_buffer(const asn_codec_ctx_t *opt_codec_ctx,
                      const asn_TYPE_descriptor_t *td, const void *sptr,
                      void *buffer, size_t buffer_size) {
     struct overrun_encoder_key buf_key;
-    asn_enc_rval_t er;
+    asn_enc_rval_t er = {0,0,0};
 
     if(buffer_size > 0 && !buffer) {
         errno = EINVAL;
@@ -225,7 +225,7 @@ asn_encode_internal(const asn_codec_ctx_t *opt_codec_ctx,
                     enum asn_transfer_syntax syntax,
                     const asn_TYPE_descriptor_t *td, const void *sptr,
                     asn_app_consume_bytes_f *callback, void *callback_key) {
-    asn_enc_rval_t er;
+    asn_enc_rval_t er = {0,0,0};
     enum xer_encoder_flags_e xer_flags = XER_F_CANONICAL;
 
     (void)opt_codec_ctx; /* Parameters are not checked on encode yet. */
@@ -317,6 +317,8 @@ asn_encode_internal(const asn_codec_ctx_t *opt_codec_ctx,
 #ifdef  ASN_DISABLE_PER_SUPPORT
     case ATS_UNALIGNED_BASIC_PER:
     case ATS_UNALIGNED_CANONICAL_PER:
+    case ATS_ALIGNED_BASIC_PER:
+    case ATS_ALIGNED_CANONICAL_PER:
         errno = ENOENT; /* PER is not defined. */
         ASN__ENCODE_FAILED;
         break;
@@ -332,6 +334,36 @@ asn_encode_internal(const asn_codec_ctx_t *opt_codec_ctx,
                     errno = EBADF;  /* Structure has incorrect form. */
                 } else {
                     errno = ENOENT; /* UPER is not defined for this type. */
+                }
+            } else {
+                ASN_DEBUG("Complete encoded in %ld bits", (long)er.encoded);
+                if(er.encoded == 0) {
+                    /* Enforce "Complete Encoding" of X.691 #11.1 */
+                    if(callback("\0", 1, callback_key) < 0) {
+                        errno = EBADF;
+                        ASN__ENCODE_FAILED;
+                    }
+                    er.encoded = 8; /* Exactly 8 zero bits is added. */
+                }
+                /* Convert bits into bytes */
+                er.encoded = (er.encoded + 7) >> 3;
+            }
+        } else {
+            errno = ENOENT; /* Transfer syntax is not defined for this type. */
+            ASN__ENCODE_FAILED;
+        }
+        break;
+    case ATS_ALIGNED_BASIC_PER:
+        /* CANONICAL-APER is a superset of BASIC-APER. */
+        /* Fall through. */
+    case ATS_ALIGNED_CANONICAL_PER:
+        if(td->op->aper_encoder) {
+            er = aper_encode(td, 0, sptr, callback, callback_key);
+            if(er.encoded == -1) {
+                if(er.failed_type && er.failed_type->op->aper_encoder) {
+                    errno = EBADF;  /* Structure has incorrect form. */
+                } else {
+                    errno = ENOENT; /* APER is not defined for this type. */
                 }
             } else {
                 ASN_DEBUG("Complete encoded in %ld bits", (long)er.encoded);
@@ -430,6 +462,15 @@ asn_decode(const asn_codec_ctx_t *opt_codec_ctx,
         ASN__DECODE_FAILED;
 #else
         return uper_decode_complete(opt_codec_ctx, td, sptr, buffer, size);
+#endif
+
+    case ATS_ALIGNED_BASIC_PER:
+    case ATS_ALIGNED_CANONICAL_PER:
+#ifdef  ASN_DISABLE_PER_SUPPORT
+        errno = ENOENT;
+        ASN__DECODE_FAILED;
+#else
+        return aper_decode_complete(opt_codec_ctx, td, sptr, buffer, size);
 #endif
 
     case ATS_BASIC_XER:

--- a/skeletons/asn_application.h
+++ b/skeletons/asn_application.h
@@ -24,7 +24,7 @@ enum asn_transfer_syntax {
     ATS_INVALID = 0,
     /* Plaintext output (not conforming to any standard), for debugging. */
     ATS_NONSTANDARD_PLAINTEXT,
-    /* Returns a randomly generatede structure. */
+    /* Returns a randomly generated structure. */
     ATS_RANDOM,
     /*
      * X.690:
@@ -51,6 +51,8 @@ enum asn_transfer_syntax {
      */
     ATS_UNALIGNED_BASIC_PER,
     ATS_UNALIGNED_CANONICAL_PER,
+    ATS_ALIGNED_BASIC_PER,
+    ATS_ALIGNED_CANONICAL_PER,
     /*
      * X.693:
      * XER: XML Encoding Rules.

--- a/skeletons/asn_codecs_prim.c
+++ b/skeletons/asn_codecs_prim.c
@@ -84,7 +84,7 @@ asn_enc_rval_t
 der_encode_primitive(const asn_TYPE_descriptor_t *td, const void *sptr,
                      int tag_mode, ber_tlv_tag_t tag,
                      asn_app_consume_bytes_f *cb, void *app_key) {
-    asn_enc_rval_t erval;
+	asn_enc_rval_t erval = {0,0,0};
 	const ASN__PRIMITIVE_TYPE_t *st = (const ASN__PRIMITIVE_TYPE_t *)sptr;
 
 	ASN_DEBUG("%s %s as a primitive type (tm=%d)",

--- a/skeletons/asn_internal.c
+++ b/skeletons/asn_internal.c
@@ -17,6 +17,7 @@ asn__format_to_callback(int (*cb)(const void *, size_t, void *key), void *key,
         if(wrote < (ssize_t)buf_size) {
             if(wrote < 0) {
                 if(buf != scratch) FREEMEM(buf);
+		va_end(args);
                 return -1;
             }
             break;

--- a/skeletons/asn_internal.h
+++ b/skeletons/asn_internal.h
@@ -7,9 +7,8 @@
  */
 #ifndef	ASN_INTERNAL_H
 #define	ASN_INTERNAL_H
-#ifndef __EXTENSIONS__
 #define __EXTENSIONS__          /* for Sun */
-#endif
+
 #include "asn_application.h"	/* Application-visible API */
 
 #ifndef	__NO_ASSERT_H__		/* Include assert.h only for internal use. */
@@ -43,7 +42,8 @@ int get_asn1c_environment_version(void);	/* Run-time version */
  */
 #ifndef	ASN_DEBUG	/* If debugging code is not defined elsewhere... */
 #if	ASN_EMIT_DEBUG == 1	/* And it was asked to emit this code... */
-#if __STDC_VERSION__ >= 199901L
+#if !defined(BELL_LABS) /* Bell Labs */
+  //#if __STDC_VERSION__ >= 199901L
 #ifdef	ASN_THREAD_SAFE
 /* Thread safety requires sacrifice in output indentation:
  * Retain empty definition of ASN_DEBUG_INDENT_ADD. */
@@ -53,6 +53,12 @@ int get_asn1c_environment_version(void);	/* Run-time version */
 int asn_debug_indent;
 #define ASN_DEBUG_INDENT_ADD(i) do { asn_debug_indent += i; } while(0)
 #endif	/* ASN_THREAD_SAFE */
+#if defined(BELL_LABS) /* Bell Labs version */
+extern int logAsn1c(const char *filename, int linenumber, const char *format, ...);  
+#define	ASN_DEBUG(fmt, args...)	do {		        \
+    (void) logAsn1c(__FILE__, __LINE__, fmt, ##args);	\
+  } while(0)
+#else  
 #define	ASN_DEBUG(fmt, args...)	do {			\
 		int adi = asn_debug_indent;		\
 		while(adi--) fprintf(stderr, " ");	\
@@ -60,6 +66,7 @@ int asn_debug_indent;
 		fprintf(stderr, " (%s:%d)\n",		\
 			__FILE__, __LINE__);		\
 	} while(0)
+#endif /* BELL_LABS */  
 #else	/* !C99 */
 void CC_PRINTFLIKE(1, 2) ASN_DEBUG_f(const char *fmt, ...);
 #define	ASN_DEBUG	ASN_DEBUG_f

--- a/skeletons/asn_ioc.h
+++ b/skeletons/asn_ioc.h
@@ -28,6 +28,7 @@ typedef struct asn_ioc_set_s {
 typedef struct asn_ioc_cell_s {
     const char *field_name; /* Is equal to corresponding column_name */
     enum {
+        aioc__undefined = 0,
         aioc__value,
         aioc__type,
         aioc__open_type,

--- a/skeletons/ber_tlv_length.c
+++ b/skeletons/ber_tlv_length.c
@@ -123,7 +123,7 @@ ber_skip_length(const asn_codec_ctx_t *opt_codec_ctx,
 
 		ptr = ((const char *)ptr) + tl + ll;
 		size -= tl + ll;
- 	}
+	}
 
 	/* UNREACHABLE */
 }

--- a/skeletons/constr_CHOICE.c
+++ b/skeletons/constr_CHOICE.c
@@ -365,7 +365,7 @@ CHOICE_encode_der(const asn_TYPE_descriptor_t *td, const void *sptr,
                   void *app_key) {
     const asn_CHOICE_specifics_t *specs = (const asn_CHOICE_specifics_t *)td->specifics;
 	asn_TYPE_member_t *elm;	/* CHOICE element */
-	asn_enc_rval_t erval;
+	asn_enc_rval_t erval = {0,0,0};
 	const void *memb_ptr;
 	size_t computed_size = 0;
 	unsigned present;
@@ -779,10 +779,10 @@ asn_enc_rval_t
 CHOICE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
                   enum xer_encoder_flags_e flags, asn_app_consume_bytes_f *cb,
                   void *app_key) {
-    const asn_CHOICE_specifics_t *specs =
-        (const asn_CHOICE_specifics_t *)td->specifics;
-    asn_enc_rval_t er;
-	unsigned present;
+	const asn_CHOICE_specifics_t *specs =
+        	(const asn_CHOICE_specifics_t *)td->specifics;
+	asn_enc_rval_t er = {0,0,0};
+	unsigned present = 0;
 
 	if(!sptr)
 		ASN__ENCODE_FAILED;
@@ -795,9 +795,9 @@ CHOICE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
 	if(present == 0 || present > td->elements_count) {
 		ASN__ENCODE_FAILED;
 	}  else {
-		asn_enc_rval_t tmper;
+		asn_enc_rval_t tmper = {0,0,0};
 		asn_TYPE_member_t *elm = &td->elements[present-1];
-		const void *memb_ptr;
+		const void *memb_ptr = NULL;
 		const char *mname = elm->name;
 		unsigned int mlen = strlen(mname);
 
@@ -920,7 +920,7 @@ asn_enc_rval_t
 CHOICE_encode_uper(const asn_TYPE_descriptor_t *td,
                    const asn_per_constraints_t *constraints, const void *sptr,
                    asn_per_outp_t *po) {
-    const asn_CHOICE_specifics_t *specs = (const asn_CHOICE_specifics_t *)td->specifics;
+	const asn_CHOICE_specifics_t *specs = (const asn_CHOICE_specifics_t *)td->specifics;
 	asn_TYPE_member_t *elm;	/* CHOICE's element */
 	const asn_per_constraint_t *ct;
 	const void *memb_ptr;
@@ -997,7 +997,7 @@ CHOICE_encode_uper(const asn_TYPE_descriptor_t *td,
         return elm->type->op->uper_encoder(
             elm->type, elm->encoding_constraints.per_constraints, memb_ptr, po);
     } else {
-        asn_enc_rval_t rval;
+        asn_enc_rval_t rval = {0,0,0};
         if(specs->ext_start == -1) ASN__ENCODE_FAILED;
         if(uper_put_nsnnwn(po, present_enc - specs->ext_start))
             ASN__ENCODE_FAILED;
@@ -1010,6 +1010,195 @@ CHOICE_encode_uper(const asn_TYPE_descriptor_t *td,
     }
 }
 
+asn_dec_rval_t
+CHOICE_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
+                   const asn_TYPE_descriptor_t *td,
+                   const asn_per_constraints_t *constraints, void **sptr, asn_per_data_t *pd) {
+	const asn_CHOICE_specifics_t *specs = (const asn_CHOICE_specifics_t *)td->specifics;
+	asn_dec_rval_t rv;
+	const asn_per_constraint_t *ct;
+	const asn_per_constraint_t *ext_ct = NULL;
+	asn_TYPE_member_t *elm;	/* CHOICE's element */
+	void *memb_ptr;
+	void **memb_ptr2;
+	void *st = *sptr;
+	int value;
+
+	if(ASN__STACK_OVERFLOW_CHECK(opt_codec_ctx))
+		ASN__DECODE_FAILED;
+
+	/*
+	 * Create the target structure if it is not present already.
+	 */
+	if(!st) {
+		st = *sptr = CALLOC(1, specs->struct_size);
+		if(!st) ASN__DECODE_FAILED;
+	}
+
+	if(constraints) ct = &constraints->value;
+	else if(td->encoding_constraints.per_constraints)
+		ct = &td->encoding_constraints.per_constraints->value;
+	else ct = 0;
+
+	if(ct && ct->flags & APC_EXTENSIBLE) {
+		value = per_get_few_bits(pd, 1);
+		if(value < 0) ASN__DECODE_STARVED;
+		if(value) {
+		  ext_ct = ct;
+		  ct = 0;	/* Not restricted */
+		}
+	}
+
+
+	if(ct && ct->range_bits >= 0) {
+		value = per_get_few_bits(pd, ct->range_bits);
+		if(value < 0) ASN__DECODE_STARVED;
+		ASN_DEBUG("CHOICE %s got index %d in range %d",
+		          td->name, value, ct->range_bits);
+		if(value > ct->upper_bound)
+			ASN__DECODE_FAILED;
+	} else {
+		if(specs->ext_start == -1)
+			ASN__DECODE_FAILED;
+		value = aper_get_nsnnwn(pd, ext_ct->range_bits);
+		if(value < 0) ASN__DECODE_STARVED;
+		value += specs->ext_start;
+		if((unsigned)value >= td->elements_count)
+			ASN__DECODE_FAILED;
+	}
+
+	/* Adjust if canonical order is different from natural order */
+	if(specs->from_canonical_order)
+		value = specs->from_canonical_order[value];
+
+	/* Set presence to be able to free it later */
+	_set_present_idx(st, specs->pres_offset, specs->pres_size, value + 1);
+
+	elm = &td->elements[value];
+	if(elm->flags & ATF_POINTER) {
+		/* Member is a pointer to another structure */
+		memb_ptr2 = (void **)((char *)st + elm->memb_offset);
+	} else {
+		memb_ptr = (char *)st + elm->memb_offset;
+		memb_ptr2 = &memb_ptr;
+	}
+	ASN_DEBUG("Discovered CHOICE %s encodes %s", td->name, elm->name);
+
+	if(ct && ct->range_bits >= 0) {
+		rv = elm->type->op->aper_decoder(opt_codec_ctx, elm->type,
+		                                 elm->encoding_constraints.per_constraints, memb_ptr2, pd);
+	} else {
+		rv = aper_open_type_get(opt_codec_ctx, elm->type,
+		                        elm->encoding_constraints.per_constraints, memb_ptr2, pd);
+	}
+
+	if(rv.code != RC_OK)
+		ASN_DEBUG("Failed to decode %s in %s (CHOICE) %d",
+		          elm->name, td->name, rv.code);
+	return rv;
+}
+
+asn_enc_rval_t
+CHOICE_encode_aper(const asn_TYPE_descriptor_t *td,
+                   const asn_per_constraints_t *constraints,
+                   const void *sptr, asn_per_outp_t *po) {
+	const asn_CHOICE_specifics_t *specs = (const asn_CHOICE_specifics_t *)td->specifics;
+	const asn_TYPE_member_t *elm; /* CHOICE's element */
+	const asn_per_constraint_t *ct = NULL;
+	const asn_per_constraint_t *ext_ct = NULL;
+	const void *memb_ptr;
+	unsigned present;
+	int present_enc;
+	
+	if(!sptr) ASN__ENCODE_FAILED;
+
+	ASN_DEBUG("Encoding %s as CHOICE using ALIGNED PER", td->name);
+
+	if(constraints) ct = &constraints->value;
+	else if(td->encoding_constraints.per_constraints)
+		ct = &td->encoding_constraints.per_constraints->value;
+	else ct = NULL;
+
+	present = _fetch_present_idx(sptr,
+	                             specs->pres_offset, specs->pres_size);
+
+	/*
+	 * If the structure was not initialized properly, it cannot be encoded:
+	 * can't deduce what to encode in the choice type.
+	 */
+	if(present <= 0 || (unsigned)present > td->elements_count)
+		ASN__ENCODE_FAILED;
+	else
+		present--;
+
+	/* Adjust if canonical order is different from natural order */
+	if(specs->to_canonical_order)
+		present_enc = specs->to_canonical_order[present];
+	else
+	        present_enc = present;
+	
+	ASN_DEBUG("Encoding %s CHOICE element %d", td->name, present);
+
+	if(ct && (ct->range_bits >= 0)) {
+	  // Value is not within the range of the primary values ?
+	  if(present < ct->lower_bound || present > ct->upper_bound) {
+	    if(ct->flags & APC_EXTENSIBLE) {
+	      ASN_DEBUG("CHOICE member %d (enc %d) is an extension (%ld..%ld)",
+			present, present_enc, ct->lower_bound, ct->upper_bound);
+	      // X691/23.5 Extension marker = 1 
+	      if(per_put_few_bits(po, 1, 1)) {
+		ASN__ENCODE_FAILED;
+	      }
+	    } else {
+	      ASN__ENCODE_FAILED;
+	    }
+	    // no more need of constraint.
+	    ext_ct = ct;
+	    ct = NULL;
+	  }
+	}
+	
+	if(ct && (ct->flags & APC_EXTENSIBLE)) {
+	  ASN_DEBUG("CHOICE member %d (enc %d) is not an extension (%ld..%ld)",
+		    present, present, ct->lower_bound, ct->upper_bound);
+	  // X691.23.5 Extension marker = 0
+	  if(per_put_few_bits(po, 0, 1)) {
+	    ASN__ENCODE_FAILED;
+	  }
+	}
+
+	elm = &td->elements[present];
+	if(elm->flags & ATF_POINTER) {
+		/* Member is a pointer to another structure */
+		memb_ptr = *(const void *const *)((const char *)sptr + elm->memb_offset);
+		if(!memb_ptr) ASN__ENCODE_FAILED;
+	} else {
+		memb_ptr = (const char *)sptr + elm->memb_offset;
+	}
+
+	if(ct && (ct->range_bits >= 0)) {
+	        // By construction (ct != 0), the alternative value is a non extended one.
+	        // X691/23.7 X691/23.6 alternative value encoded as a range_bits bits value.
+		if(per_put_few_bits(po, present_enc, ct->range_bits))
+			ASN__ENCODE_FAILED;
+
+		return elm->type->op->aper_encoder(elm->type, elm->encoding_constraints.per_constraints,
+		                                   memb_ptr, po);
+	} else {
+		asn_enc_rval_t rval = {0,0,0};
+		if(specs->ext_start == -1)
+			ASN__ENCODE_FAILED;
+		// X691/23.8 normally encoded as a small non negative whole number
+		
+		if(ext_ct && aper_put_nsnnwn(po, ext_ct->range_bits, present_enc - specs->ext_start))
+			ASN__ENCODE_FAILED;
+		if(aper_open_type_put(elm->type, elm->encoding_constraints.per_constraints,
+		                      memb_ptr, po))
+			ASN__ENCODE_FAILED;
+		rval.encoded = 0;
+		ASN__ENCODED_OK(rval);
+	}
+}
 
 int
 CHOICE_print(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
@@ -1331,9 +1520,13 @@ asn_TYPE_operation_t asn_OP_CHOICE = {
 #ifdef ASN_DISABLE_PER_SUPPORT
 	0,
 	0,
+	0,
+	0,
 #else
 	CHOICE_decode_uper,
 	CHOICE_encode_uper,
+	CHOICE_decode_aper,
+	CHOICE_encode_aper,
 #endif	/* ASN_DISABLE_PER_SUPPORT */
 	CHOICE_random_fill,
 	CHOICE_outmost_tag

--- a/skeletons/constr_CHOICE.h
+++ b/skeletons/constr_CHOICE.h
@@ -51,6 +51,8 @@ oer_type_decoder_f CHOICE_decode_oer;
 oer_type_encoder_f CHOICE_encode_oer;
 per_type_decoder_f CHOICE_decode_uper;
 per_type_encoder_f CHOICE_encode_uper;
+per_type_decoder_f CHOICE_decode_aper;
+per_type_encoder_f CHOICE_encode_aper;
 asn_outmost_tag_f CHOICE_outmost_tag;
 asn_random_fill_f CHOICE_random_fill;
 extern asn_TYPE_operation_t asn_OP_CHOICE;

--- a/skeletons/constr_SEQUENCE.c
+++ b/skeletons/constr_SEQUENCE.c
@@ -512,7 +512,7 @@ SEQUENCE_encode_der(const asn_TYPE_descriptor_t *td, const void *sptr,
                     int tag_mode, ber_tlv_tag_t tag,
                     asn_app_consume_bytes_f *cb, void *app_key) {
     size_t computed_size = 0;
-	asn_enc_rval_t erval;
+	asn_enc_rval_t erval = {0,0,0};
 	ssize_t ret;
 	size_t edx;
 
@@ -574,7 +574,7 @@ SEQUENCE_encode_der(const asn_TYPE_descriptor_t *td, const void *sptr,
 	 */
 	for(edx = 0; edx < td->elements_count; edx++) {
 		asn_TYPE_member_t *elm = &td->elements[edx];
-		asn_enc_rval_t tmperval;
+		asn_enc_rval_t tmperval = {0,0,0};
         const void *memb_ptr;           /* Pointer to the member */
         const void *const *memb_ptr2;   /* Pointer to that pointer */
 
@@ -868,18 +868,18 @@ asn_enc_rval_t
 SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
                     int ilevel, enum xer_encoder_flags_e flags,
                     asn_app_consume_bytes_f *cb, void *app_key) {
-    asn_enc_rval_t er;
+    asn_enc_rval_t er = {0,0,0};
     int xcan = (flags & XER_F_CANONICAL);
     asn_TYPE_descriptor_t *tmp_def_val_td = 0;
     void *tmp_def_val = 0;
-	size_t edx;
+    size_t edx;
 
     if(!sptr) ASN__ENCODE_FAILED;
 
     er.encoded = 0;
 
     for(edx = 0; edx < td->elements_count; edx++) {
-        asn_enc_rval_t tmper;
+        asn_enc_rval_t tmper = {0,0,0};
         asn_TYPE_member_t *elm = &td->elements[edx];
         const void *memb_ptr;
         const char *mname = elm->name;
@@ -1357,7 +1357,7 @@ SEQUENCE_encode_uper(const asn_TYPE_descriptor_t *td,
                      asn_per_outp_t *po) {
     const asn_SEQUENCE_specifics_t *specs
 		= (const asn_SEQUENCE_specifics_t *)td->specifics;
-	asn_enc_rval_t er;
+	asn_enc_rval_t er = {0,0,0};
 	int n_extensions;
 	size_t edx;
 	size_t i;
@@ -1484,6 +1484,435 @@ SEQUENCE_encode_uper(const asn_TYPE_descriptor_t *td,
 	ASN__ENCODED_OK(er);
 }
 
+asn_dec_rval_t
+SEQUENCE_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
+                     const asn_TYPE_descriptor_t *td,
+                     const asn_per_constraints_t *constraints, void **sptr, asn_per_data_t *pd) {
+	const asn_SEQUENCE_specifics_t *specs = (const asn_SEQUENCE_specifics_t *)td->specifics;
+	void *st = *sptr;	/* Target structure. */
+	int extpresent;		/* Extension additions are present */
+	uint8_t *opres;		/* Presence of optional root members */
+	asn_per_data_t opmd;
+	asn_dec_rval_t rv;
+	size_t edx;
+
+	(void)constraints;
+
+	if(ASN__STACK_OVERFLOW_CHECK(opt_codec_ctx))
+		ASN__DECODE_FAILED;
+
+	if(!st) {
+		st = *sptr = CALLOC(1, specs->struct_size);
+		if(!st) ASN__DECODE_FAILED;
+	}
+
+	ASN_DEBUG("Decoding %s as SEQUENCE (APER)", td->name);
+
+	/* Handle extensions */
+	if(specs->first_extension < 0) {
+		extpresent = 0;
+	} else {
+		extpresent = per_get_few_bits(pd, 1);
+		if(extpresent < 0) ASN__DECODE_STARVED;
+	}
+
+	/* Prepare a place and read-in the presence bitmap */
+	memset(&opmd, 0, sizeof(opmd));
+	if(specs->roms_count) {
+		opres = (uint8_t *)MALLOC(((specs->roms_count + 7) >> 3) + 1);
+		if(!opres) ASN__DECODE_FAILED;
+		/* Get the presence map */
+		if(per_get_many_bits(pd, opres, 0, specs->roms_count)) {
+			FREEMEM(opres);
+			ASN__DECODE_STARVED;
+		}
+		opmd.buffer = opres;
+		opmd.nbits = specs->roms_count;
+		ASN_DEBUG("Read in presence bitmap for %s of %d bits (%x..)",
+		          td->name, specs->roms_count, *opres);
+	} else {
+		opres = 0;
+	}
+
+	/*
+	 * Get the sequence ROOT elements.
+	 */
+	for(edx = 0; edx < td->elements_count; edx++) {
+		asn_TYPE_member_t *elm = &td->elements[edx];
+		void *memb_ptr;		/* Pointer to the member */
+		void **memb_ptr2;	/* Pointer to that pointer */
+#if 0
+		int padding;
+#endif
+
+		if(IN_EXTENSION_GROUP(specs, edx))
+			continue;
+
+		/* Fetch the pointer to this member */
+		if(elm->flags & ATF_POINTER) {
+			memb_ptr2 = (void **)((char *)st + elm->memb_offset);
+		} else {
+			memb_ptr = (char *)st + elm->memb_offset;
+			memb_ptr2 = &memb_ptr;
+		}
+#if 0
+		/* Get Padding */
+		padding = (8 - (pd->moved % 8)) % 8;
+		if(padding > 0)
+			ASN_DEBUG("For element %s,offset= %ld Padding bits = %d", td->name, pd->moved, padding);
+#if 0 /* old way of removing padding */
+		per_get_few_bits(pd, padding);
+#else /* Experimental fix proposed by @mhanna123 */
+		if(edx != (td->elements_count-1))
+			per_get_few_bits(pd, padding);
+		else {
+			if(specs->roms_count && (padding > 0))
+				ASN_DEBUG(">>>>> not skipping padding of %d bits for element:%ld out of %d", padding, edx, td->elements_count);
+			else
+				per_get_few_bits(pd, padding);
+		}
+#endif /* dealing with padding */
+#endif
+		/* Deal with optionality */
+		if(elm->optional) {
+			int present = per_get_few_bits(&opmd, 1);
+			ASN_DEBUG("Member %s->%s is optional, p=%d (%d->%d)",
+			          td->name, elm->name, present,
+			          (int)opmd.nboff, (int)opmd.nbits);
+			if(present == 0) {
+				/* This element is not present */
+				if(elm->default_value_set) {
+					/* Fill-in DEFAULT */
+					if(elm->default_value_set(memb_ptr2)) {
+						FREEMEM(opres);
+						ASN__DECODE_FAILED;
+					}
+					ASN_DEBUG("Filled-in default");
+				}
+				/* The member is just not present */
+				continue;
+			}
+			/* Fall through */
+		}
+
+		/* Fetch the member from the stream */
+		ASN_DEBUG("Decoding member \"%s\" in %s", elm->name, td->name);
+
+		if(elm->flags & ATF_OPEN_TYPE) {
+			rv = OPEN_TYPE_aper_get(opt_codec_ctx, td, st, elm, pd);
+		} else {
+			rv = elm->type->op->aper_decoder(opt_codec_ctx, elm->type,
+					elm->encoding_constraints.per_constraints, memb_ptr2, pd);
+		}
+		if(rv.code != RC_OK) {
+			ASN_DEBUG("Failed decode %s in %s",
+			          elm->name, td->name);
+			FREEMEM(opres);
+			return rv;
+		}
+	}
+
+	/* Optionality map is not needed anymore */
+	FREEMEM(opres);
+
+	/*
+	 * Deal with extensions.
+	 */
+	if(extpresent) {
+		ssize_t bmlength;
+		uint8_t *epres;		/* Presence of extension members */
+		asn_per_data_t epmd;
+
+		bmlength = aper_get_nslength(pd);
+		if(bmlength < 0) ASN__DECODE_STARVED;
+
+		ASN_DEBUG("Extensions %" ASN_PRI_SSIZE " present in %s", bmlength, td->name);
+
+		epres = (uint8_t *)MALLOC((bmlength + 15) >> 3);
+		if(!epres) ASN__DECODE_STARVED;
+
+		/* Get the extensions map */
+		if(per_get_many_bits(pd, epres, 0, bmlength))
+			ASN__DECODE_STARVED;
+
+		memset(&epmd, 0, sizeof(epmd));
+		epmd.buffer = epres;
+		epmd.nbits = bmlength;
+		ASN_DEBUG("Read in extensions bitmap for %s of %ld bits (%x..)",
+		          td->name, bmlength, *epres);
+
+		/* Go over extensions and read them in */
+		for(edx = specs->first_extension; edx < td->elements_count; edx++) {
+			asn_TYPE_member_t *elm = &td->elements[edx];
+			void *memb_ptr;		/* Pointer to the member */
+			void **memb_ptr2;	/* Pointer to that pointer */
+			int present;
+
+			if(!IN_EXTENSION_GROUP(specs, edx)) {
+				ASN_DEBUG("%ld is not extension", edx);
+				continue;
+			}
+
+			/* Fetch the pointer to this member */
+			if(elm->flags & ATF_POINTER) {
+				memb_ptr2 = (void **)((char *)st + elm->memb_offset);
+			} else {
+				memb_ptr = (void *)((char *)st + elm->memb_offset);
+				memb_ptr2 = &memb_ptr;
+			}
+
+			present = per_get_few_bits(&epmd, 1);
+			if(present <= 0) {
+				if(present < 0) break;	/* No more extensions */
+				continue;
+			}
+
+			ASN_DEBUG("Decoding member %s in %s %p", elm->name, td->name, *memb_ptr2);
+			rv = aper_open_type_get(opt_codec_ctx, elm->type,
+			                        elm->encoding_constraints.per_constraints, memb_ptr2, pd);
+			if(rv.code != RC_OK) {
+				FREEMEM(epres);
+				return rv;
+			}
+		}
+
+		/* Skip over overflow extensions which aren't present
+		 * in this system's version of the protocol */
+		for(;;) {
+			ASN_DEBUG("Getting overflow extensions");
+			switch(per_get_few_bits(&epmd, 1)) {
+			case -1:
+				break;
+			case 0:
+				continue;
+			default:
+				if(aper_open_type_skip(opt_codec_ctx, pd)) {
+					FREEMEM(epres);
+					ASN__DECODE_STARVED;
+				}
+			}
+			break;
+		}
+
+		FREEMEM(epres);
+	}
+
+	/* Fill DEFAULT members in extensions */
+	for(edx = specs->roms_count; edx < specs->roms_count
+	        + specs->aoms_count; edx++) {
+		asn_TYPE_member_t *elm = &td->elements[edx];
+		void **memb_ptr2;	/* Pointer to member pointer */
+
+		if(!elm->default_value_set) continue;
+
+		/* Fetch the pointer to this member */
+		if(elm->flags & ATF_POINTER) {
+			memb_ptr2 = (void **)((char *)st
+			                      + elm->memb_offset);
+			if(*memb_ptr2) continue;
+		} else {
+			continue;	/* Extensions are all optionals */
+		}
+
+		/* Set default value */
+		if(elm->default_value_set(memb_ptr2)) {
+			ASN__DECODE_FAILED;
+		}
+	}
+
+	rv.consumed = 0;
+	rv.code = RC_OK;
+	return rv;
+}
+
+static int
+SEQUENCE_handle_extensions_aper(const asn_TYPE_descriptor_t *td,
+                                const void *sptr,
+                                asn_per_outp_t *po1, asn_per_outp_t *po2) {
+	const asn_SEQUENCE_specifics_t *specs
+	    = (const asn_SEQUENCE_specifics_t *)td->specifics;
+	int exts_present = 0;
+	int exts_count = 0;
+	size_t edx;
+
+	if(specs->first_extension < 0) {
+		return 0;
+	}
+
+	/* Find out which extensions are present */
+	for(edx = specs->first_extension; edx < td->elements_count; edx++) {
+		asn_TYPE_member_t *elm = &td->elements[edx];
+		const void *memb_ptr;           /* Pointer to the member */
+		const void * const *memb_ptr2;  /* Pointer to that pointer */
+		int present;
+
+		if(!IN_EXTENSION_GROUP(specs, edx)) {
+			ASN_DEBUG("%s (@%ld) is not extension", elm->type->name, edx);
+			continue;
+		}
+
+		/* Fetch the pointer to this member */
+		if(elm->flags & ATF_POINTER) {
+			memb_ptr2 = (const void * const *)((const char *)sptr + elm->memb_offset);
+			present = (*memb_ptr2 != 0);
+		} else {
+			memb_ptr = (const void *)((const char *)sptr + elm->memb_offset);
+			memb_ptr2 = &memb_ptr;
+			present = 1;
+		}
+
+		ASN_DEBUG("checking %s (@%ld) present => %d",
+		          elm->type->name, edx, present);
+		exts_count++;
+		exts_present += present;
+
+		/* Encode as presence marker */
+		if(po1 && per_put_few_bits(po1, present, 1))
+			return -1;
+		/* Encode as open type field */
+		if(po2 && present && aper_open_type_put(elm->type,
+		                                        elm->encoding_constraints.per_constraints, *memb_ptr2, po2))
+			return -1;
+
+	}
+
+	return exts_present ? exts_count : 0;
+}
+
+asn_enc_rval_t
+SEQUENCE_encode_aper(const asn_TYPE_descriptor_t *td,
+                     const asn_per_constraints_t *constraints,
+                     const void *sptr, asn_per_outp_t *po) {
+	const asn_SEQUENCE_specifics_t *specs
+	    = (const asn_SEQUENCE_specifics_t *)td->specifics;
+	asn_enc_rval_t er = {0,0,0};
+	int n_extensions;
+	size_t edx;
+	size_t i;
+
+	(void)constraints;
+
+	if(!sptr)
+		ASN__ENCODE_FAILED;
+
+	er.encoded = 0;
+
+	ASN_DEBUG("Encoding %s as SEQUENCE (APER)", td->name);
+
+	/*
+	 * X.691#18.1 Whether structure is extensible
+	 * and whether to encode extensions
+	 */
+	if(specs->first_extension < 0) {
+		n_extensions = 0; /* There are no extensions to encode */
+	} else {
+		n_extensions = SEQUENCE_handle_extensions_aper(td, sptr, 0, 0);
+		if(n_extensions < 0) ASN__ENCODE_FAILED;
+		if(per_put_few_bits(po, n_extensions ? 1 : 0, 1)) {
+			ASN__ENCODE_FAILED;
+		}
+	}
+
+	/* Encode a presence bitmap */
+	for(i = 0; i < specs->roms_count; i++) {
+		asn_TYPE_member_t *elm;
+		const void *memb_ptr;	 /* Pointer to the member */
+		const void * const *memb_ptr2;       /* Pointer to that pointer */
+		int present;
+
+		edx = specs->oms[i];
+		elm = &td->elements[edx];
+
+		/* Fetch the pointer to this member */
+		if(elm->flags & ATF_POINTER) {
+			memb_ptr2 = (const void * const *)((const char *)sptr + elm->memb_offset);
+			present = (*memb_ptr2 != 0);
+		} else {
+			memb_ptr = (const void *)((const char *)sptr + elm->memb_offset);
+			memb_ptr2 = &memb_ptr;
+			present = 1;
+		}
+
+		/* Eliminate default values */
+		if(present && elm->default_value_cmp
+		        && elm->default_value_cmp(memb_ptr2) == 1)
+			present = 0;
+
+		ASN_DEBUG("Element %s %s %s->%s is %s",
+		          elm->flags & ATF_POINTER ? "ptr" : "inline",
+		          elm->default_value_cmp ? "def" : "wtv",
+		          td->name, elm->name, present ? "present" : "absent");
+		if(per_put_few_bits(po, present, 1))
+			ASN__ENCODE_FAILED;
+	}
+
+	/*
+	 * Encode the sequence ROOT elements.
+	 */
+	ASN_DEBUG("first_extension = %d, elements = %d", specs->first_extension,
+              td->elements_count);
+	for(edx = 0;
+		edx < ((specs->first_extension < 0) ? td->elements_count
+                                            : (size_t)specs->first_extension);
+		edx++) {
+		asn_TYPE_member_t *elm = &td->elements[edx];
+		const void *memb_ptr;          /* Pointer to the member */
+		const void * const *memb_ptr2; /* Pointer to that pointer */
+
+		if(IN_EXTENSION_GROUP(specs, edx))
+			continue;
+
+		ASN_DEBUG("About to encode %s", elm->type->name);
+
+		/* Fetch the pointer to this member */
+		if(elm->flags & ATF_POINTER) {
+			memb_ptr2 = (const void * const *)((const char *)sptr + elm->memb_offset);
+			if(!*memb_ptr2) {
+				ASN_DEBUG("Element %s %ld not present",
+				          elm->name, edx);
+				if(elm->optional)
+					continue;
+				/* Mandatory element is missing */
+				ASN__ENCODE_FAILED;
+			}
+		} else {
+			memb_ptr = (const void *)((const char *)sptr + elm->memb_offset);
+			memb_ptr2 = &memb_ptr;
+		}
+
+		/* Eliminate default values */
+		if(elm->default_value_cmp && elm->default_value_cmp(memb_ptr2) == 1)
+			continue;
+
+		ASN_DEBUG("Encoding %s->%s", td->name, elm->name);
+		er = elm->type->op->aper_encoder(elm->type, elm->encoding_constraints.per_constraints,
+		                                 *memb_ptr2, po);
+		if(er.encoded == -1)
+			return er;
+	}
+
+	/* No extensions to encode */
+	if(!n_extensions) ASN__ENCODED_OK(er);
+
+	ASN_DEBUG("Length of %d bit-map", n_extensions);
+	/* #18.8. Write down the presence bit-map length. */
+	if(aper_put_nslength(po, n_extensions))
+		ASN__ENCODE_FAILED;
+
+	ASN_DEBUG("Bit-map of %d elements", n_extensions);
+	/* #18.7. Encoding the extensions presence bit-map. */
+	/* TODO: act upon NOTE in #18.7 for canonical PER */
+	if(SEQUENCE_handle_extensions_aper(td, sptr, po, 0) != n_extensions)
+		ASN__ENCODE_FAILED;
+
+	ASN_DEBUG("Writing %d extensions", n_extensions);
+	/* #18.9. Encode extensions as open type fields. */
+	if(SEQUENCE_handle_extensions_aper(td, sptr, 0, po) != n_extensions)
+		ASN__ENCODE_FAILED;
+
+	ASN__ENCODED_OK(er);
+}
+
 #endif  /* ASN_DISABLE_PER_SUPPORT */
 
 int
@@ -1548,9 +1977,13 @@ asn_TYPE_operation_t asn_OP_SEQUENCE = {
 #ifdef ASN_DISABLE_PER_SUPPORT
 	0,
 	0,
+	0,
+	0,
 #else
 	SEQUENCE_decode_uper,
 	SEQUENCE_encode_uper,
+	SEQUENCE_decode_aper,
+	SEQUENCE_encode_aper,
 #endif /* ASN_DISABLE_PER_SUPPORT */
 	SEQUENCE_random_fill,
 	0	/* Use generic outmost tag fetcher */

--- a/skeletons/constr_SEQUENCE.h
+++ b/skeletons/constr_SEQUENCE.h
@@ -56,6 +56,8 @@ oer_type_decoder_f SEQUENCE_decode_oer;
 oer_type_encoder_f SEQUENCE_encode_oer;
 per_type_decoder_f SEQUENCE_decode_uper;
 per_type_encoder_f SEQUENCE_encode_uper;
+per_type_decoder_f SEQUENCE_decode_aper;
+per_type_encoder_f SEQUENCE_encode_aper;
 asn_random_fill_f  SEQUENCE_random_fill;
 extern asn_TYPE_operation_t asn_OP_SEQUENCE;
 

--- a/skeletons/constr_SEQUENCE_OF.c
+++ b/skeletons/constr_SEQUENCE_OF.c
@@ -18,7 +18,7 @@ SEQUENCE_OF_encode_der(const asn_TYPE_descriptor_t *td, const void *ptr,
 	const asn_anonymous_sequence_ *list = _A_CSEQUENCE_FROM_VOID(ptr);
 	size_t computed_size = 0;
 	ssize_t encoding_size = 0;
-	asn_enc_rval_t erval;
+	asn_enc_rval_t erval = {0,0,0};
 	int edx;
 
 	ASN_DEBUG("Estimating size of SEQUENCE OF %s", td->name);
@@ -91,7 +91,7 @@ asn_enc_rval_t
 SEQUENCE_OF_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
                        int ilevel, enum xer_encoder_flags_e flags,
                        asn_app_consume_bytes_f *cb, void *app_key) {
-    asn_enc_rval_t er;
+    asn_enc_rval_t er = {0,0,0};
     const asn_SET_OF_specifics_t *specs = (const asn_SET_OF_specifics_t *)td->specifics;
     const asn_TYPE_member_t *elm = td->elements;
     const asn_anonymous_sequence_ *list = _A_CSEQUENCE_FROM_VOID(sptr);
@@ -107,7 +107,7 @@ SEQUENCE_OF_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
     er.encoded = 0;
 
     for(i = 0; i < list->count; i++) {
-        asn_enc_rval_t tmper;
+        asn_enc_rval_t tmper = {0,0,0};
         void *memb_ptr = list->array[i];
         if(!memb_ptr) continue;
 
@@ -147,7 +147,7 @@ SEQUENCE_OF_encode_uper(const asn_TYPE_descriptor_t *td,
                         const void *sptr, asn_per_outp_t *po) {
     const asn_anonymous_sequence_ *list;
 	const asn_per_constraint_t *ct;
-	asn_enc_rval_t er;
+	asn_enc_rval_t er = {0,0,0};
 	const asn_TYPE_member_t *elm = td->elements;
 	size_t encoded_edx;
 
@@ -225,6 +225,76 @@ SEQUENCE_OF_encode_uper(const asn_TYPE_descriptor_t *td,
 	ASN__ENCODED_OK(er);
 }
 
+asn_enc_rval_t
+SEQUENCE_OF_encode_aper(const asn_TYPE_descriptor_t *td,
+                        const asn_per_constraints_t *constraints,
+                        const void *sptr, asn_per_outp_t *po) {
+	const asn_anonymous_sequence_ *list;
+	const asn_per_constraint_t *ct;
+	asn_enc_rval_t er = {0,0,0};
+	asn_TYPE_member_t *elm = td->elements;
+	int seq;
+
+	if(!sptr) ASN__ENCODE_FAILED;
+	list = _A_CSEQUENCE_FROM_VOID(sptr);
+
+	er.encoded = 0;
+
+	ASN_DEBUG("Encoding %s as SEQUENCE OF size (%d) using ALIGNED PER", td->name, list->count);
+
+	if(constraints) ct = &constraints->size;
+	else if(td->encoding_constraints.per_constraints)
+		ct = &td->encoding_constraints.per_constraints->size;
+	else ct = 0;
+
+	/* If extensible constraint, check if size is in root */
+	if(ct) {
+		int not_in_root = (list->count < ct->lower_bound
+				|| list->count > ct->upper_bound);
+		ASN_DEBUG("lb %ld ub %ld %s",
+			ct->lower_bound, ct->upper_bound,
+			ct->flags & APC_EXTENSIBLE ? "ext" : "fix");
+		if(ct->flags & APC_EXTENSIBLE) {
+			/* Declare whether size is in extension root */
+			if(per_put_few_bits(po, not_in_root, 1))
+				ASN__ENCODE_FAILED;
+			if(not_in_root) ct = 0;
+		} else if(not_in_root && ct->effective_bits >= 0)
+			ASN__ENCODE_FAILED;
+	}
+
+	if(ct && ct->effective_bits >= 0) {
+		/* X.691, #19.5: No length determinant */
+/*		 if(per_put_few_bits(po, list->count - ct->lower_bound,
+				 ct->effective_bits))
+			 ASN__ENCODE_FAILED;
+*/
+		if (aper_put_length(po, ct->upper_bound - ct->lower_bound + 1, list->count - ct->lower_bound) < 0)
+			ASN__ENCODE_FAILED;
+	}
+
+	for(seq = -1; seq < list->count;) {
+		ssize_t mayEncode;
+		if(seq < 0) seq = 0;
+		if(ct && ct->effective_bits >= 0) {
+			mayEncode = list->count;
+		} else {
+			mayEncode = aper_put_length(po, -1, list->count - seq);
+			if(mayEncode < 0) ASN__ENCODE_FAILED;
+		}
+
+		while(mayEncode--) {
+			void *memb_ptr = list->array[seq++];
+			if(!memb_ptr) ASN__ENCODE_FAILED;
+			er = elm->type->op->aper_encoder(elm->type,
+				elm->encoding_constraints.per_constraints, memb_ptr, po);
+			if(er.encoded == -1)
+				ASN__ENCODE_FAILED;
+		}
+	}
+
+	ASN__ENCODED_OK(er);
+}
 #endif  /* ASN_DISABLE_PER_SUPPORT */
 
 int
@@ -274,9 +344,13 @@ asn_TYPE_operation_t asn_OP_SEQUENCE_OF = {
 #ifdef ASN_DISABLE_PER_SUPPORT
 	0,
 	0,
+	0,
+	0,
 #else
 	SEQUENCE_OF_decode_uper, /* Same as SET OF decoder */
 	SEQUENCE_OF_encode_uper,
+	SEQUENCE_OF_decode_aper,
+	SEQUENCE_OF_encode_aper,
 #endif /* ASN_DISABLE_PER_SUPPORT */
 	SEQUENCE_OF_random_fill,
 	0	/* Use generic outmost tag fetcher */

--- a/skeletons/constr_SEQUENCE_OF.h
+++ b/skeletons/constr_SEQUENCE_OF.h
@@ -20,6 +20,7 @@ asn_struct_compare_f SEQUENCE_OF_compare;
 der_type_encoder_f SEQUENCE_OF_encode_der;
 xer_type_encoder_f SEQUENCE_OF_encode_xer;
 per_type_encoder_f SEQUENCE_OF_encode_uper;
+per_type_encoder_f SEQUENCE_OF_encode_aper;
 extern asn_TYPE_operation_t asn_OP_SEQUENCE_OF;
 
 #define	SEQUENCE_OF_free	SET_OF_free
@@ -27,9 +28,10 @@ extern asn_TYPE_operation_t asn_OP_SEQUENCE_OF;
 #define	SEQUENCE_OF_constraint	SET_OF_constraint
 #define	SEQUENCE_OF_decode_ber	SET_OF_decode_ber
 #define	SEQUENCE_OF_decode_xer	SET_OF_decode_xer
-#define	SEQUENCE_OF_decode_uper	SET_OF_decode_uper
 #define	SEQUENCE_OF_decode_oer  SET_OF_decode_oer
 #define	SEQUENCE_OF_encode_oer  SET_OF_encode_oer
+#define	SEQUENCE_OF_decode_uper	SET_OF_decode_uper
+#define	SEQUENCE_OF_decode_aper	SET_OF_decode_aper
 #define	SEQUENCE_OF_random_fill SET_OF_random_fill
 
 #ifdef __cplusplus

--- a/skeletons/constr_SET_OF.c
+++ b/skeletons/constr_SET_OF.c
@@ -371,7 +371,7 @@ SET_OF__encode_sorted(const asn_TYPE_member_t *elm,
     for(edx = 0; edx < list->count; edx++) {
         const void *memb_ptr = list->array[edx];
         struct _el_buffer *encoding_el = &encoded_els[edx];
-        asn_enc_rval_t erval;
+        asn_enc_rval_t erval = {0,0,0};
 
         if(!memb_ptr) break;
 
@@ -435,7 +435,7 @@ SET_OF_encode_der(const asn_TYPE_descriptor_t *td, const void *sptr,
      */
     for(edx = 0; edx < list->count; edx++) {
         void *memb_ptr = list->array[edx];
-        asn_enc_rval_t erval;
+        asn_enc_rval_t erval = {0,0,0};
 
         if(!memb_ptr) ASN__ENCODE_FAILED;
 
@@ -457,7 +457,7 @@ SET_OF_encode_der(const asn_TYPE_descriptor_t *td, const void *sptr,
     computed_size += encoding_size;
 
     if(!cb || list->count == 0) {
-        asn_enc_rval_t erval;
+        asn_enc_rval_t erval = {0,0,0};
         erval.encoded = computed_size;
         ASN__ENCODED_OK(erval);
     }
@@ -488,7 +488,7 @@ SET_OF_encode_der(const asn_TYPE_descriptor_t *td, const void *sptr,
     SET_OF__encode_sorted_free(encoded_els, list->count);
 
     if(edx == list->count) {
-        asn_enc_rval_t erval;
+        asn_enc_rval_t erval = {0,0,0};
         assert(computed_size == (size_t)encoding_size);
         erval.encoded = computed_size;
         ASN__ENCODED_OK(erval);
@@ -526,7 +526,7 @@ SET_OF_decode_xer(const asn_codec_ctx_t *opt_codec_ctx,
 	void *st = *struct_ptr;	/* Target structure. */
 	asn_struct_ctx_t *ctx;	/* Decoder context */
 
-	asn_dec_rval_t rval;		/* Return value from a decoder */
+	asn_dec_rval_t rval = {RC_OK, 0};/* Return value from a decoder */
 	ssize_t consumed_myself = 0;	/* Consumed bytes from ptr */
 
 	/*
@@ -565,7 +565,7 @@ SET_OF_decode_xer(const asn_codec_ctx_t *opt_codec_ctx,
 		 * Go inside the inner member of a set.
 		 */
 		if(ctx->phase == 2) {
-			asn_dec_rval_t tmprval;
+			asn_dec_rval_t tmprval = {RC_OK, 0};
 
 			/* Invoke the inner type decoder, m.b. multiple times */
 			ASN_DEBUG("XER/SET OF element [%s]", elm_tag);
@@ -697,7 +697,7 @@ asn_enc_rval_t
 SET_OF_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
                   enum xer_encoder_flags_e flags, asn_app_consume_bytes_f *cb,
                   void *app_key) {
-    asn_enc_rval_t er;
+    asn_enc_rval_t er = {0,0,0};
 	const asn_SET_OF_specifics_t *specs = (const asn_SET_OF_specifics_t *)td->specifics;
 	const asn_TYPE_member_t *elm = td->elements;
     const asn_anonymous_set_ *list = _A_CSET_FROM_VOID(sptr);
@@ -722,7 +722,7 @@ SET_OF_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
 	er.encoded = 0;
 
 	for(i = 0; i < list->count; i++) {
-		asn_enc_rval_t tmper;
+		asn_enc_rval_t tmper = {0,0,0};
 
 		void *memb_ptr = list->array[i];
 		if(!memb_ptr) continue;
@@ -909,7 +909,7 @@ SET_OF_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
                    const asn_TYPE_descriptor_t *td,
                    const asn_per_constraints_t *constraints, void **sptr,
                    asn_per_data_t *pd) {
-    asn_dec_rval_t rv;
+    asn_dec_rval_t rv = {RC_OK, 0};
 	const asn_SET_OF_specifics_t *specs = (const asn_SET_OF_specifics_t *)td->specifics;
     const asn_TYPE_member_t *elm = td->elements; /* Single one */
     void *st = *sptr;
@@ -1007,7 +1007,7 @@ SET_OF_encode_uper(const asn_TYPE_descriptor_t *td,
     const asn_per_constraint_t *ct;
     const asn_TYPE_member_t *elm = td->elements;
     struct _el_buffer *encoded_els;
-    asn_enc_rval_t er;
+    asn_enc_rval_t er = {0,0,0};
     size_t encoded_edx;
 
     if(!sptr) ASN__ENCODE_FAILED;
@@ -1097,6 +1097,95 @@ SET_OF_encode_uper(const asn_TYPE_descriptor_t *td,
     }
 }
 
+asn_dec_rval_t
+SET_OF_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
+                   const asn_TYPE_descriptor_t *td,
+                   const asn_per_constraints_t *constraints, void **sptr, asn_per_data_t *pd) {
+	asn_dec_rval_t rv = {RC_OK, 0};
+	const asn_SET_OF_specifics_t *specs = (const asn_SET_OF_specifics_t *)td->specifics;
+	const asn_TYPE_member_t *elm = td->elements; /* Single one */
+	void *st = *sptr;
+	asn_anonymous_set_ *list;
+	const asn_per_constraint_t *ct;
+	int repeat = 0;
+	ssize_t nelems;
+
+	if(ASN__STACK_OVERFLOW_CHECK(opt_codec_ctx))
+		ASN__DECODE_FAILED;
+
+	/*
+	 * Create the target structure if it is not present already.
+	 */
+	if(!st) {
+		st = *sptr = CALLOC(1, specs->struct_size);
+		if(!st) ASN__DECODE_FAILED;
+	}
+	list = _A_SET_FROM_VOID(st);
+
+	/* Figure out which constraints to use */
+	if(constraints) ct = &constraints->size;
+	else if(td->encoding_constraints.per_constraints)
+		ct = &td->encoding_constraints.per_constraints->size;
+	else ct = 0;
+
+	if(ct && ct->flags & APC_EXTENSIBLE) {
+		int value = per_get_few_bits(pd, 1);
+		if(value < 0) ASN__DECODE_STARVED;
+		if(value) ct = 0;	/* Not restricted! */
+	}
+
+	if(ct && ct->effective_bits >= 0) {
+		/* X.691, #19.5: No length determinant */
+		nelems = aper_get_nsnnwn(pd, ct->upper_bound - ct->lower_bound + 1);
+		ASN_DEBUG("Preparing to fetch %ld+%ld elements from %s",
+		          (long)nelems, ct->lower_bound, td->name);
+		if(nelems < 0)  ASN__DECODE_STARVED;
+		nelems += ct->lower_bound;
+	} else {
+		nelems = -1;
+	}
+
+	do {
+		int i;
+		if(nelems < 0) {
+			nelems = aper_get_length(pd, ct ? ct->upper_bound - ct->lower_bound + 1 : -1,
+			                         ct ? ct->effective_bits : -1, &repeat);
+			ASN_DEBUG("Got to decode %d elements (eff %d)",
+			          (int)nelems, (int)(ct ? ct->effective_bits : -1));
+			if(nelems < 0) ASN__DECODE_STARVED;
+		}
+
+		for(i = 0; i < nelems; i++) {
+			void *ptr = 0;
+			ASN_DEBUG("SET OF %s decoding", elm->type->name);
+			rv = elm->type->op->aper_decoder(opt_codec_ctx, elm->type,
+			                                 elm->encoding_constraints.per_constraints, &ptr, pd);
+			ASN_DEBUG("%s SET OF %s decoded %d, %p",
+			          td->name, elm->type->name, rv.code, ptr);
+			if(rv.code == RC_OK) {
+				if(ASN_SET_ADD(list, ptr) == 0)
+					continue;
+				ASN_DEBUG("Failed to add element into %s",
+				          td->name);
+				/* Fall through */
+				rv.code = RC_FAIL;
+			} else {
+				ASN_DEBUG("Failed decoding %s of %s (SET OF)",
+				          elm->type->name, td->name);
+			}
+			if(ptr) ASN_STRUCT_FREE(*elm->type, ptr);
+			return rv;
+		}
+
+		nelems = -1;	/* Allow uper_get_length() */
+	} while(repeat);
+
+	ASN_DEBUG("Decoded %s as SET OF", td->name);
+
+	rv.code = RC_OK;
+	rv.consumed = 0;
+	return rv;
+}
 
 #endif  /* ASN_DISABLE_PER_SUPPORT */
 
@@ -1198,9 +1287,13 @@ asn_TYPE_operation_t asn_OP_SET_OF = {
 #ifdef ASN_DISABLE_PER_SUPPORT
 	0,
 	0,
+	0,
+	0,
 #else
 	SET_OF_decode_uper,
 	SET_OF_encode_uper,
+	SET_OF_decode_aper,
+	0,	/* SET_OF_encode_aper */
 #endif /* ASN_DISABLE_PER_SUPPORT */
 	SET_OF_random_fill,
 	0	/* Use generic outmost tag fetcher */

--- a/skeletons/constr_SET_OF.h
+++ b/skeletons/constr_SET_OF.h
@@ -37,6 +37,8 @@ oer_type_decoder_f SET_OF_decode_oer;
 oer_type_encoder_f SET_OF_encode_oer;
 per_type_decoder_f SET_OF_decode_uper;
 per_type_encoder_f SET_OF_encode_uper;
+per_type_decoder_f SET_OF_decode_aper;
+per_type_encoder_f SET_OF_encode_aper;
 asn_random_fill_f  SET_OF_random_fill;
 extern asn_TYPE_operation_t asn_OP_SET_OF;
 

--- a/skeletons/constr_TYPE.h
+++ b/skeletons/constr_TYPE.h
@@ -153,6 +153,8 @@ typedef struct asn_TYPE_operation_s {
     oer_type_encoder_f *oer_encoder;      /* Canonical OER encoder */
     per_type_decoder_f *uper_decoder;     /* Unaligned PER decoder */
     per_type_encoder_f *uper_encoder;     /* Unaligned PER encoder */
+    per_type_decoder_f *aper_decoder;     /* Aligned PER decoder */
+    per_type_encoder_f *aper_encoder;     /* Aligned PER encoder */
     asn_random_fill_f *random_fill;       /* Initialize with a random value */
     asn_outmost_tag_f *outmost_tag;       /* <optional, internal> */
 } asn_TYPE_operation_t;

--- a/skeletons/per_decoder.c
+++ b/skeletons/per_decoder.c
@@ -95,3 +95,91 @@ uper_decode(const asn_codec_ctx_t *opt_codec_ctx,
 	return rval;
 }
 
+asn_dec_rval_t
+aper_decode_complete(const asn_codec_ctx_t *opt_codec_ctx,
+                     const asn_TYPE_descriptor_t *td, void **sptr,
+                     const void *buffer, size_t size) {
+	asn_dec_rval_t rval;
+
+	rval = aper_decode(opt_codec_ctx, td, sptr, buffer, size, 0, 0);
+	if(rval.consumed) {
+		/*
+		 * We've always given 8-aligned data,
+		 * so convert bits to integral bytes.
+		 */
+		rval.consumed += 7;
+		rval.consumed >>= 3;
+	} else if(rval.code == RC_OK) {
+		if(size) {
+			if(((const uint8_t *)buffer)[0] == 0) {
+				rval.consumed = 1;	/* 1 byte */
+			} else {
+				ASN_DEBUG("Expecting single zeroed byte");
+				rval.code = RC_FAIL;
+			}
+		} else {
+			/* Must contain at least 8 bits. */
+			rval.code = RC_WMORE;
+		}
+	}
+
+	return rval;
+}
+
+asn_dec_rval_t
+aper_decode(const asn_codec_ctx_t *opt_codec_ctx,
+            const asn_TYPE_descriptor_t *td, void **sptr, const void *buffer,
+            size_t size, int skip_bits, int unused_bits) {
+	asn_codec_ctx_t s_codec_ctx;
+	asn_dec_rval_t rval;
+	asn_per_data_t pd;
+
+	if(skip_bits < 0 || skip_bits > 7
+		|| unused_bits < 0 || unused_bits > 7
+		|| (unused_bits > 0 && !size))
+		ASN__DECODE_FAILED;
+
+	/*
+	 * Stack checker requires that the codec context
+	 * must be allocated on the stack.
+	 */
+	if(opt_codec_ctx) {
+		if(opt_codec_ctx->max_stack_size) {
+			s_codec_ctx = *opt_codec_ctx;
+			opt_codec_ctx = &s_codec_ctx;
+		}
+	} else {
+		/* If context is not given, be security-conscious anyway */
+		memset(&s_codec_ctx, 0, sizeof(s_codec_ctx));
+		s_codec_ctx.max_stack_size = ASN__DEFAULT_STACK_MAX;
+		opt_codec_ctx = &s_codec_ctx;
+	}
+
+	/* Fill in the position indicator */
+	memset(&pd, 0, sizeof(pd));
+	pd.buffer = (const uint8_t *)buffer;
+	pd.nboff = skip_bits;
+	pd.nbits = 8 * size - unused_bits; /* 8 is CHAR_BIT from <limits.h> */
+	if(pd.nboff > pd.nbits)
+		ASN__DECODE_FAILED;
+
+	/*
+	 * Invoke type-specific decoder.
+	 */
+	if(!td->op->aper_decoder)
+		ASN__DECODE_FAILED;	/* PER is not compiled in */
+		rval = td->op->aper_decoder(opt_codec_ctx, td, 0, sptr, &pd);
+	if(rval.code == RC_OK) {
+		/* Return the number of consumed bits */
+		rval.consumed = ((pd.buffer - (const uint8_t *)buffer) << 3)
+		+ pd.nboff - skip_bits;
+		ASN_DEBUG("PER decoding consumed %zu, counted %zu",
+				  rval.consumed, pd.moved);
+		assert(rval.consumed == pd.moved);
+	} else {
+		/* PER codec is not a restartable */
+		rval.consumed = 0;
+	}
+	return rval;
+}
+

--- a/skeletons/per_decoder.h
+++ b/skeletons/per_decoder.h
@@ -40,6 +40,31 @@ asn_dec_rval_t uper_decode(
     int unused_bits     /* Number of unused tailing bits, 0..7 */
 );
 
+/*
+ * Aligned PER decoder of a "complete encoding" as per X.691#10.1.
+ * On success, this call always returns (.consumed >= 1), in BITS, as per X.691#10.1.3.
+ */
+asn_dec_rval_t aper_decode_complete(
+       const struct asn_codec_ctx_s *opt_codec_ctx,
+       const struct asn_TYPE_descriptor_s *type_descriptor,	/* Type to decode */
+       void **struct_ptr,	/* Pointer to a target structure's pointer */
+       const void *buffer,	/* Data to be decoded */
+       size_t size		/* Size of data buffer */
+									);
+
+/*
+ * Aligned PER decoder of any ASN.1 type. May be invoked by the application.
+ * WARNING: This call returns the number of BITS read from the stream. Beware.
+ */
+asn_dec_rval_t aper_decode(
+      const struct asn_codec_ctx_s *opt_codec_ctx,
+      const struct asn_TYPE_descriptor_s *type_descriptor,	/* Type to decode */
+      void **struct_ptr,	/* Pointer to a target structure's pointer */
+      const void *buffer,	/* Data to be decoded */
+      size_t size,		/* Size of data buffer */
+      int skip_bits,		/* Number of unused leading bits, 0..7 */
+      int unused_bits		/* Number of unused tailing bits, 0..7 */
+      );
 
 /*
  * Type of the type-specific PER decoder function.

--- a/skeletons/per_encoder.c
+++ b/skeletons/per_encoder.c
@@ -17,7 +17,7 @@ uper_encode(const asn_TYPE_descriptor_t *td,
             const asn_per_constraints_t *constraints, const void *sptr,
             asn_app_consume_bytes_f *cb, void *app_key) {
     asn_per_outp_t po;
-    asn_enc_rval_t er;
+    asn_enc_rval_t er = {0,0,0};
 
     /*
      * Invoke type-specific encoder.
@@ -114,7 +114,7 @@ ssize_t
 uper_encode_to_new_buffer(const asn_TYPE_descriptor_t *td,
                           const asn_per_constraints_t *constraints,
                           const void *sptr, void **buffer_r) {
-    asn_enc_rval_t er;
+    asn_enc_rval_t er = {0,0,0};
 	enc_dyn_arg key;
 
 	memset(&key, 0, sizeof(key));
@@ -163,3 +163,103 @@ _uper_encode_flush_outp(asn_per_outp_t *po) {
 	return po->output(po->tmpspace, buf - po->tmpspace, po->op_key);
 }
 
+asn_enc_rval_t
+aper_encode_to_buffer(const asn_TYPE_descriptor_t *td,
+                      const asn_per_constraints_t *constraints,
+                      const void *sptr, void *buffer, size_t buffer_size) {
+    enc_to_buf_arg key;
+
+    key.buffer = buffer;
+    key.left = buffer_size;
+
+    if(td) ASN_DEBUG("Encoding \"%s\" using ALIGNED PER", td->name);
+
+    return aper_encode(td, constraints, sptr, encode_to_buffer_cb, &key);
+}
+
+ssize_t
+aper_encode_to_new_buffer(const asn_TYPE_descriptor_t *td,
+                          const asn_per_constraints_t *constraints,
+                          const void *sptr, void **buffer_r) {
+    asn_enc_rval_t er = {0,0,0};
+	enc_dyn_arg key;
+
+	memset(&key, 0, sizeof(key));
+
+	er = aper_encode(td, constraints, sptr, encode_dyn_cb, &key);
+	switch(er.encoded) {
+	case -1:
+		FREEMEM(key.buffer);
+		return -1;
+	case 0:
+		FREEMEM(key.buffer);
+		key.buffer = MALLOC(1);
+		if(key.buffer) {
+			*(char *)key.buffer = '\0';
+			*buffer_r = key.buffer;
+			return 1;
+		} else {
+			return -1;
+		}
+	default:
+		*buffer_r = key.buffer;
+		ASN_DEBUG("Complete encoded in %ld bits", (long)er.encoded);
+		return ((er.encoded + 7) >> 3);
+	}
+}
+
+static int
+_aper_encode_flush_outp(asn_per_outp_t *po) {
+	uint8_t *buf;
+
+	if(po->nboff == 0 && po->buffer == po->tmpspace)
+		return 0;
+
+	buf = po->buffer + (po->nboff >> 3);
+	/* Make sure we account for the last, partially filled */
+	if(po->nboff & 0x07) {
+		buf[0] &= 0xff << (8 - (po->nboff & 0x07));
+		buf++;
+	}
+
+	if (po->output) {
+		return po->output(po->tmpspace, buf - po->tmpspace, po->op_key);
+	}
+	return 0;
+}
+
+asn_enc_rval_t
+aper_encode(const asn_TYPE_descriptor_t *td,
+        const asn_per_constraints_t *constraints,
+        const void *sptr, asn_app_consume_bytes_f *cb, void *app_key) {
+	asn_per_outp_t po;
+	asn_enc_rval_t er = {0,0,0};
+
+	/*
+	 * Invoke type-specific encoder.
+	 */
+	if(!td || !td->op->aper_encoder)
+		ASN__ENCODE_FAILED;	 /* PER is not compiled in */
+
+	po.buffer = po.tmpspace;
+	po.nboff = 0;
+	po.nbits = 8 * sizeof(po.tmpspace);
+	po.output = cb;
+	po.op_key = app_key;
+	po.flushed_bytes = 0;
+
+	er = td->op->aper_encoder(td, constraints, sptr, &po);
+	if(er.encoded != -1) {
+		size_t bits_to_flush;
+
+		bits_to_flush = ((po.buffer - po.tmpspace) << 3) + po.nboff;
+
+		/* Set number of bits encoded to a firm value */
+		er.encoded = (po.flushed_bytes << 3) + bits_to_flush;
+
+		if(_aper_encode_flush_outp(&po))
+			ASN__ENCODE_FAILED;
+	}
+
+	return er;
+}

--- a/skeletons/per_encoder.h
+++ b/skeletons/per_encoder.h
@@ -28,6 +28,14 @@ asn_enc_rval_t uper_encode(
     void *app_key                              /* Arbitrary callback argument */
 );
 
+asn_enc_rval_t aper_encode(
+    const struct asn_TYPE_descriptor_s *type_descriptor,
+    const asn_per_constraints_t *constraints,
+    const void *struct_ptr,                     /* Structure to be encoded */
+    asn_app_consume_bytes_f *consume_bytes_cb,  /* Data collector */
+    void *app_key                               /* Arbitrary callback argument */
+);
+
 /*
  * A variant of uper_encode() which encodes data into the existing buffer
  * WARNING: This function returns the number of encoded bits in the .encoded
@@ -41,6 +49,13 @@ asn_enc_rval_t uper_encode_to_buffer(
     size_t buffer_size      /* Initial buffer size (max) */
 );
 
+asn_enc_rval_t aper_encode_to_buffer(
+    const struct asn_TYPE_descriptor_s *type_descriptor,
+    const asn_per_constraints_t *constraints,
+    const void *struct_ptr,  /* Structure to be encoded */
+    void *buffer,            /* Pre-allocated buffer */
+    size_t buffer_size       /* Initial buffer size (max) */
+);
 /*
  * A variant of uper_encode_to_buffer() which allocates buffer itself.
  * Returns the number of bytes in the buffer or -1 in case of failure.
@@ -53,6 +68,14 @@ ssize_t uper_encode_to_new_buffer(
     const asn_per_constraints_t *constraints,
     const void *struct_ptr, /* Structure to be encoded */
     void **buffer_r         /* Buffer allocated and returned */
+);
+
+ssize_t
+aper_encode_to_new_buffer(
+    const struct asn_TYPE_descriptor_s *td,
+    const asn_per_constraints_t *constraints,
+    const void *sptr,
+    void **buffer_r
 );
 
 /*

--- a/skeletons/per_opentype.c
+++ b/skeletons/per_opentype.c
@@ -119,7 +119,7 @@ uper_open_type_get_simple(const asn_codec_ctx_t *ctx,
 	if(rv.code == RC_OK) {
 		/* Check padding validity */
 		padding = spd.nbits - spd.nboff;
-                if ((padding < 8 ||
+                if (((padding > 0 && padding < 8) ||
 		/* X.691#10.1.3 */
 		(spd.nboff == 0 && spd.nbits == 8 && spd.buffer == buf)) &&
                     per_get_few_bits(&spd, padding) == 0) {
@@ -132,8 +132,7 @@ uper_open_type_get_simple(const asn_codec_ctx_t *ctx,
 			ASN_DEBUG("Too large padding %d in open type", (int)padding);
 			ASN__DECODE_FAILED;
 		} else {
-			ASN_DEBUG("Non-zero padding");
-			ASN__DECODE_FAILED;
+			ASN_DEBUG("No padding");
 		}
 	} else {
 		FREEMEM(buf);
@@ -295,7 +294,7 @@ uper_sot_suck(const asn_codec_ctx_t *ctx, const asn_TYPE_descriptor_t *td,
 	(void)constraints;
 	(void)sptr;
 
-	while(per_get_few_bits(pd, 24) >= 0);
+	while(per_get_few_bits(pd, 1) >= 0);
 
 	rv.code = RC_OK;
 	rv.consumed = pd->moved;
@@ -394,3 +393,141 @@ per_skip_bits(asn_per_data_t *pd, int skip_nbits) {
 	}
 	return hasNonZeroBits;
 }
+
+static asn_dec_rval_t
+aper_open_type_get_simple(const asn_codec_ctx_t *ctx,
+                          const asn_TYPE_descriptor_t *td,
+                          const asn_per_constraints_t *constraints, void **sptr, asn_per_data_t *pd) {
+	asn_dec_rval_t rv;
+	ssize_t chunk_bytes;
+	int repeat;
+	uint8_t *buf = 0;
+	size_t bufLen = 0;
+	size_t bufSize = 0;
+	asn_per_data_t spd;
+	size_t padding;
+
+	ASN__STACK_OVERFLOW_CHECK(ctx);
+
+	ASN_DEBUG("Getting open type %s...", td->name);
+
+	do {
+	        chunk_bytes = aper_get_length(pd, -1, -1, &repeat);
+		if(chunk_bytes < 0) {
+			FREEMEM(buf);
+			ASN__DECODE_STARVED;
+		}
+		if(bufLen + chunk_bytes > bufSize) {
+			void *ptr;
+			bufSize = chunk_bytes + (bufSize << 2);
+			ptr = REALLOC(buf, bufSize);
+			if(!ptr) {
+				FREEMEM(buf);
+				ASN__DECODE_FAILED;
+			}
+			buf = ptr;
+		}
+		if(per_get_many_bits(pd, buf + bufLen, 0, chunk_bytes << 3)) {
+			FREEMEM(buf);
+			ASN__DECODE_STARVED;
+		}
+		bufLen += chunk_bytes;
+	} while(repeat);
+
+	ASN_DEBUG("Getting open type %s encoded in %ld bytes", td->name,
+		(long)bufLen);
+
+	memset(&spd, 0, sizeof(spd));
+	spd.buffer = buf;
+	spd.nbits = bufLen << 3;
+
+	ASN_DEBUG_INDENT_ADD(+4);
+	rv = td->op->aper_decoder(ctx, td, constraints, sptr, &spd);
+	ASN_DEBUG_INDENT_ADD(-4);
+
+	if(rv.code == RC_OK) {
+		/* Check padding validity */
+		padding = spd.nbits - spd.nboff;
+                if (((padding > 0 && padding < 8) ||
+		/* X.691#10.1.3 */
+		(spd.nboff == 0 && spd.nbits == 8 && spd.buffer == buf)) &&
+                    per_get_few_bits(&spd, padding) == 0) {
+			/* Everything is cool */
+			FREEMEM(buf);
+			return rv;
+		}
+		FREEMEM(buf);
+		if(padding >= 8) {
+			ASN_DEBUG("Too large padding %d in open type", (int)padding);
+			ASN__DECODE_FAILED;
+		} else {
+			ASN_DEBUG("No padding");
+		}
+	} else {
+		FREEMEM(buf);
+		/* rv.code could be RC_WMORE, nonsense in this context */
+		rv.code = RC_FAIL; /* Noone would give us more */
+	}
+
+	return rv;
+}
+
+int
+aper_open_type_put(const asn_TYPE_descriptor_t *td,
+                   const asn_per_constraints_t *constraints,
+                   const void *sptr, asn_per_outp_t *po) {
+	void *buf;
+	void *bptr;
+	ssize_t size;
+	size_t toGo;
+
+	ASN_DEBUG("Open type put %s ...", td->name);
+
+	size = aper_encode_to_new_buffer(td, constraints, sptr, &buf);
+	if(size <= 0) return -1;
+
+	for(bptr = buf, toGo = size; toGo;) {
+		ssize_t maySave = aper_put_length(po, -1, toGo);
+		if(maySave < 0) break;
+		if(per_put_many_bits(po, bptr, maySave * 8)) break;
+		bptr = (char *)bptr + maySave;
+		toGo -= maySave;
+	}
+
+	FREEMEM(buf);
+	if(toGo) return -1;
+
+	ASN_DEBUG("Open type put %s of length %ld + overhead (1byte?)",
+			  td->name, size);
+
+	return 0;
+}
+
+asn_dec_rval_t
+aper_open_type_get(const asn_codec_ctx_t *ctx,
+                   const asn_TYPE_descriptor_t *td,
+                   const asn_per_constraints_t *constraints,
+                   void **sptr, asn_per_data_t *pd) {
+
+	return aper_open_type_get_simple(ctx, td, constraints, sptr, pd);
+}
+
+int
+aper_open_type_skip(const asn_codec_ctx_t *ctx, asn_per_data_t *pd) {
+	asn_TYPE_descriptor_t s_td;
+	asn_dec_rval_t rv;
+	asn_TYPE_operation_t op_t;
+
+	memset(&op_t, 0, sizeof(op_t));
+	s_td.name = "<unknown extension>";
+	s_td.op = &op_t;
+	s_td.op->aper_decoder = uper_sot_suck;
+
+	rv = aper_open_type_get(ctx, &s_td, 0, 0, pd);
+	if(rv.code != RC_OK)
+		return -1;
+	else
+		return 0;
+}
+
+

--- a/skeletons/per_opentype.h
+++ b/skeletons/per_opentype.h
@@ -25,6 +25,18 @@ int uper_open_type_put(const asn_TYPE_descriptor_t *td,
                        const asn_per_constraints_t *constraints,
                        const void *sptr, asn_per_outp_t *po);
 
+asn_dec_rval_t aper_open_type_get(const asn_codec_ctx_t *opt_codec_ctx,
+                                  const asn_TYPE_descriptor_t *td,
+                                  const asn_per_constraints_t *constraints,
+                                  void **sptr, asn_per_data_t *pd);
+
+
+int aper_open_type_skip(const asn_codec_ctx_t *opt_codec_ctx, asn_per_data_t *pd);
+
+int aper_open_type_put(const asn_TYPE_descriptor_t *td,
+                       const asn_per_constraints_t *constraints,
+                       const void *sptr, asn_per_outp_t *po);
+
 #ifdef __cplusplus
 }
 #endif

--- a/skeletons/per_support.c
+++ b/skeletons/per_support.c
@@ -293,3 +293,197 @@ per_long_range_unrebase(unsigned long inp, long lb, long ub, long *outp) {
 
     return 0;
 }
+
+int32_t
+aper_get_align(asn_per_data_t *pd) {
+
+	if(pd->nboff & 0x7) {
+		ASN_DEBUG("Aligning %ld bits", 8 - ((unsigned long)pd->nboff & 0x7));
+		return per_get_few_bits(pd, 8 - (pd->nboff & 0x7));
+	}
+	return 0;
+}
+
+ssize_t
+aper_get_length(asn_per_data_t *pd, int range, int ebits, int *repeat) {
+	ssize_t value;
+
+	*repeat = 0;
+
+	if (range <= 65536 && range >= 0)
+		return aper_get_nsnnwn(pd, range);
+
+	if (aper_get_align(pd) < 0)
+		return -1;
+
+	if(ebits >= 0) return per_get_few_bits(pd, ebits);
+
+	value = per_get_few_bits(pd, 8);
+	if(value < 0) return -1;
+	if((value & 128) == 0)  /* #10.9.3.6 */
+		return (value & 0x7F);
+	if((value & 64) == 0) { /* #10.9.3.7 */
+		value = ((value & 63) << 8) | per_get_few_bits(pd, 8);
+		if(value < 0) return -1;
+		return value;
+	}
+	value &= 63;	/* this is "m" from X.691, #10.9.3.8 */
+	if(value < 1 || value > 4)
+		return -1;
+	*repeat = 1;
+	return (16384 * value);
+}
+
+ssize_t
+aper_get_nslength(asn_per_data_t *pd) {
+	ssize_t length;
+
+	ASN_DEBUG("Getting normally small length");
+
+	if(per_get_few_bits(pd, 1) == 0) {
+		length = per_get_few_bits(pd, 6) + 1;
+		if(length <= 0) return -1;
+		ASN_DEBUG("l=%ld", length);
+		return length;
+	} else {
+		int repeat;
+		length = aper_get_length(pd, -1, -1, &repeat);
+		if(length >= 0 && !repeat) return length;
+		return -1; /* Error, or do not support >16K extensions */
+	}
+}
+
+ssize_t
+aper_get_nsnnwn(asn_per_data_t *pd, int range) {
+	ssize_t value;
+	int bytes = 0;
+
+	ASN_DEBUG("getting nsnnwn with range %d", range);
+
+	if(range <= 255) {
+		int i;
+
+		if (range < 0) return -1;
+		/* 1 -> 8 bits */
+		for (i = 1; i <= 8; i++) {
+			int upper = 1 << i;
+			if (upper >= range)
+				break;
+		}
+		value = per_get_few_bits(pd, i);
+		return value;
+	} else if (range == 256){
+		/* 1 byte */
+		bytes = 1;
+	} else if (range <= 65536) {
+		/* 2 bytes */
+		bytes = 2;
+	} else {
+		return -1;
+	}
+	if (aper_get_align(pd) < 0)
+		return -1;
+	value = per_get_few_bits(pd, 8 * bytes);
+	return value;
+}
+
+int aper_put_align(asn_per_outp_t *po) {
+
+	if(po->nboff & 0x7) {
+		ASN_DEBUG("Aligning %ld bits", 8 - ((unsigned long)po->nboff & 0x7));
+		if(per_put_few_bits(po, 0x00, (8 - (po->nboff & 0x7))))
+			return -1;
+	}
+	return 0;
+}
+
+ssize_t
+aper_put_length(asn_per_outp_t *po, int range, size_t length) {
+
+	ASN_DEBUG("APER put length %zu with range %d", length, range);
+
+	/* 10.9 X.691 Note 2 */
+	if (range <= 65536 && range >= 0)
+		return aper_put_nsnnwn(po, range, length);
+
+	if (aper_put_align(po) < 0)
+		return -1;
+
+	if(length <= 127)	   /* #10.9.3.6 */{
+		return per_put_few_bits(po, length, 8)
+		? -1 : (ssize_t)length;
+	}
+	else if(length < 16384) /* #10.9.3.7 */
+		return per_put_few_bits(po, length|0x8000, 16)
+		? -1 : (ssize_t)length;
+
+	length >>= 14;
+	if(length > 4) length = 4;
+
+	return per_put_few_bits(po, 0xC0 | length, 8)
+	? -1 : (ssize_t)(length << 14);
+}
+
+
+int
+aper_put_nslength(asn_per_outp_t *po, size_t length) {
+
+	if(length <= 64) {
+		/* #10.9.3.4 */
+		if(length == 0) return -1;
+		return per_put_few_bits(po, length-1, 7) ? -1 : 0;
+	} else {
+		if(aper_put_length(po, -1, length) != (ssize_t)length) {
+			/* This might happen in case of >16K extensions */
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+int
+aper_put_nsnnwn(asn_per_outp_t *po, int range, int number) {
+	int bytes;
+
+    ASN_DEBUG("aper put nsnnwn %d with range %d", number, range);
+	/* 10.5.7.1 X.691 */
+	if(range < 0) {
+		int i;
+		for (i = 1; ; i++) {
+			int bits = 1 << (8 * i);
+			if (number <= bits)
+				break;
+		}
+		bytes = i;
+		assert(i <= 4);
+	}
+	if(range <= 255) {
+		int i;
+		for (i = 1; i <= 8; i++) {
+			int bits = 1 << i;
+			if (range <= bits)
+				break;
+		}
+		return per_put_few_bits(po, number, i);
+	} else if(range == 256) {
+		bytes = 1;
+	} else if(range <= 65536) {
+		bytes = 2;
+	} else { /* Ranges > 64K */
+		int i;
+		for (i = 1; ; i++) {
+			int bits = 1 << (8 * i);
+			if (range <= bits)
+				break;
+		}
+		assert(i <= 4);
+		bytes = i;
+	}
+	if(aper_put_align(po) < 0) /* Aligning on octet */
+		return -1;
+/* 	if(per_put_few_bits(po, bytes, 8))
+		return -1;
+*/
+    return per_put_few_bits(po, number, 8 * bytes);
+}

--- a/skeletons/per_support.h
+++ b/skeletons/per_support.h
@@ -48,15 +48,20 @@ typedef struct asn_bit_data_s asn_per_data_t;
 ssize_t uper_get_length(asn_per_data_t *pd, int effective_bound_bits,
                         size_t lower_bound, int *repeat);
 
+ssize_t aper_get_length(asn_per_data_t *pd, int range,
+                        int effective_bound_bits, int *repeat);
+
 /*
  * Get the normally small length "n".
  */
 ssize_t uper_get_nslength(asn_per_data_t *pd);
+ssize_t aper_get_nslength(asn_per_data_t *pd);
 
 /*
  * Get the normally small non-negative whole number.
  */
 ssize_t uper_get_nsnnwn(asn_per_data_t *pd);
+ssize_t aper_get_nsnnwn(asn_per_data_t *pd, int range);
 
 /* X.691-2008/11, #11.5.6 */
 int uper_get_constrained_whole_number(asn_per_data_t *pd, unsigned long *v, int nbits);
@@ -94,16 +99,26 @@ int uper_put_constrained_whole_number_u(asn_per_outp_t *po, unsigned long v, int
 ssize_t uper_put_length(asn_per_outp_t *po, size_t whole_length,
                         int *opt_need_eom);
 
+ssize_t aper_put_length(asn_per_outp_t *po, int range, size_t length);
+
+/* Align the current bit position to octet bundary */
+int aper_put_align(asn_per_outp_t *po);
+int32_t aper_get_align(asn_per_data_t *pd);
+
 /*
  * Put the normally small length "n" to the Unaligned PER stream.
  * Returns 0 or -1.
  */
 int uper_put_nslength(asn_per_outp_t *po, size_t length);
 
+int aper_put_nslength(asn_per_outp_t *po, size_t length);
+
 /*
  * Put the normally small non-negative whole number.
  */
 int uper_put_nsnnwn(asn_per_outp_t *po, int n);
+
+int aper_put_nsnnwn(asn_per_outp_t *po, int range, int number);
 
 #ifdef __cplusplus
 }

--- a/skeletons/xer_encoder.c
+++ b/skeletons/xer_encoder.c
@@ -53,7 +53,7 @@ xer__print2fp(const void *buffer, size_t size, void *app_key) {
 
 int
 xer_fprint(FILE *stream, const asn_TYPE_descriptor_t *td, const void *sptr) {
-    asn_enc_rval_t er;
+	asn_enc_rval_t er = {0,0,0};
 
 	if(!stream) stream = stdout;
 	if(!td || !sptr)


### PR DESCRIPTION
The O-RAN project uses a modified version of skeletons that include APER encoding